### PR TITLE
fix(types): mypy --strict for scoring/differ/model (22 → 0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
           pip install mypy types-PyYAML
           python -m mypy src/faultray/model/ --ignore-missing-imports
 
+      - name: Type check core engine with mypy --strict
+        run: |
+          pip install mypy types-PyYAML types-networkx
+          python -m mypy --strict src/faultray/model/ src/faultray/scoring.py src/faultray/differ.py
+
       - name: Run property-based tests
         run: pytest tests/test_property_based.py -v --tb=short --noconftest
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ dev = [
     "mypy>=1.0",
     "pytest-cov>=5.0",
     "types-PyYAML>=6.0",
+    "types-networkx>=3.0",
     "stripe>=8.0",
     "authlib>=1.3",
     "python-jose[cryptography]>=3.3",

--- a/src/faultray/differ.py
+++ b/src/faultray/differ.py
@@ -9,8 +9,13 @@ import json
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+ScenarioInfo = dict[str, Any]
+ResultDict = dict[str, Any]
 
 # Thresholds for severity classification (matches engine.py)
 CRITICAL_THRESHOLD = 7.0
@@ -35,7 +40,7 @@ class DiffResult:
 class SimulationDiffer:
     """Compares two simulation result sets and produces a DiffResult."""
 
-    def diff(self, before: dict, after: dict) -> DiffResult:
+    def diff(self, before: ResultDict, after: ResultDict) -> DiffResult:
         """Compare two simulation result dicts.
 
         Both *before* and *after* are expected to follow the JSON export
@@ -110,16 +115,16 @@ class SimulationDiffer:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _scenario_map(data: dict) -> dict[str, dict]:
+    def _scenario_map(data: ResultDict) -> dict[str, ScenarioInfo]:
         """Build a mapping of scenario_name -> scenario info dict."""
-        scenarios: dict[str, dict] = {}
+        scenarios: dict[str, ScenarioInfo] = {}
         for r in data.get("results", []):
             name = r.get("scenario_name", r.get("name", "unknown"))
             scenarios[name] = r
         return scenarios
 
     @staticmethod
-    def _detect_component_changes(before: dict, after: dict) -> list[str]:
+    def _detect_component_changes(before: ResultDict, after: ResultDict) -> list[str]:
         """Detect added/removed components between two runs."""
         changes: list[str] = []
 

--- a/src/faultray/model/graph.py
+++ b/src/faultray/model/graph.py
@@ -21,7 +21,7 @@ class InfraGraph:
     """Directed graph of infrastructure components and their dependencies."""
 
     def __init__(self) -> None:
-        self._graph = nx.DiGraph()
+        self._graph: nx.DiGraph[str] = nx.DiGraph()
         self._components: dict[str, Component] = {}
 
     @property

--- a/src/faultray/model/loader.py
+++ b/src/faultray/model/loader.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -40,7 +41,7 @@ from faultray.model.graph import InfraGraph
 logger = logging.getLogger(__name__)
 
 
-def _check_schema_version(raw: dict) -> None:
+def _check_schema_version(raw: dict[str, Any]) -> None:
     """Check schema_version in the YAML data and log a warning if outdated."""
     version = raw.get("schema_version")
     if version is None:
@@ -290,7 +291,7 @@ def load_yaml(path: Path | str) -> InfraGraph:
     return graph
 
 
-def load_yaml_with_ops(path: Path | str) -> tuple[InfraGraph, dict]:
+def load_yaml_with_ops(path: Path | str) -> tuple[InfraGraph, dict[str, Any]]:
     """Load infrastructure definition and operational simulation config from YAML.
 
     In addition to building the :class:`InfraGraph` via :func:`load_yaml`, this
@@ -313,7 +314,7 @@ def load_yaml_with_ops(path: Path | str) -> tuple[InfraGraph, dict]:
 
     # Parse additional ops sections from the raw YAML
     raw = yaml.safe_load(path.read_text(encoding="utf-8"))
-    ops_config: dict = {
+    ops_config: dict[str, Any] = {
         "slos": [SLOTarget(**s) for s in raw.get("slos", [])],
         "operational_simulation": raw.get("operational_simulation", {}),
     }

--- a/src/faultray/scoring.py
+++ b/src/faultray/scoring.py
@@ -15,14 +15,53 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable, TypedDict
 
 import yaml
 
-from faultray.model.components import ComponentType
+from faultray.model.components import Component, ComponentType
 from faultray.model.graph import InfraGraph
 
 logger = logging.getLogger(__name__)
+
+
+def _filter_components_by_type(
+    graph: InfraGraph, comp_type_str: str
+) -> list[Component]:
+    """Filter components by type string (case-insensitive).
+
+    Returns all components if comp_type_str is empty, an empty list if the
+    string is not a known ComponentType, otherwise the matching subset.
+    """
+    if not comp_type_str:
+        return list(graph.components.values())
+
+    try:
+        comp_type = ComponentType(comp_type_str.lower())
+    except ValueError:
+        logger.warning(
+            "Unknown component type '%s', returning empty list", comp_type_str
+        )
+        return []
+
+    return [c for c in graph.components.values() if c.type == comp_type]
+
+
+# Built-in check functions accept user-supplied params loaded from YAML.
+# The structure varies per check_fn (e.g. min_replicas vs max_utilization),
+# so dict[str, Any] reflects the genuinely dynamic nature of the input.
+CheckParams = dict[str, Any]
+
+
+class RuleResultRow(TypedDict, total=False):
+    """One row in CustomScoringResult.rules — output of evaluating one ScoringRule."""
+
+    name: str
+    score: float
+    weight: float
+    description: str
+    passed: bool
+    error: str  # only present when the check failed
 
 
 @dataclass
@@ -33,7 +72,7 @@ class ScoringRule:
     description: str
     weight: float = 1.0
     check_fn: str = ""  # function name to call (key in BUILT_IN_CHECKS)
-    params: dict = field(default_factory=dict)
+    params: CheckParams = field(default_factory=dict)
 
 
 @dataclass
@@ -42,7 +81,7 @@ class CustomScoringResult:
 
     model_name: str
     total_score: float  # 0-100
-    rules: list[dict]  # [{name, score, weight, description, passed}]
+    rules: list[RuleResultRow]  # [{name, score, weight, description, passed}]
     weighted_score: float
 
 
@@ -50,7 +89,7 @@ class CustomScoringResult:
 # Built-in check functions
 # ---------------------------------------------------------------------------
 
-def _check_min_replicas(graph: InfraGraph, params: dict) -> float:
+def _check_min_replicas(graph: InfraGraph, params: CheckParams) -> float:
     """Check that components of a given type have >= N replicas.
 
     Params:
@@ -70,7 +109,7 @@ def _check_min_replicas(graph: InfraGraph, params: dict) -> float:
     return (passing / len(target_comps)) * 100.0
 
 
-def _check_max_utilization(graph: InfraGraph, params: dict) -> float:
+def _check_max_utilization(graph: InfraGraph, params: CheckParams) -> float:
     """Check that no component exceeds N% utilization.
 
     Params:
@@ -90,7 +129,7 @@ def _check_max_utilization(graph: InfraGraph, params: dict) -> float:
     return (passing / len(graph.components)) * 100.0
 
 
-def _check_encryption_coverage(graph: InfraGraph, params: dict) -> float:
+def _check_encryption_coverage(graph: InfraGraph, params: CheckParams) -> float:
     """Check percentage of components with encryption enabled.
 
     Params:
@@ -114,7 +153,7 @@ def _check_encryption_coverage(graph: InfraGraph, params: dict) -> float:
     return min(100.0, (coverage / min_percent) * 100.0)
 
 
-def _check_failover_coverage(graph: InfraGraph, params: dict) -> float:
+def _check_failover_coverage(graph: InfraGraph, params: CheckParams) -> float:
     """Check percentage of components with failover enabled.
 
     Params:
@@ -138,7 +177,7 @@ def _check_failover_coverage(graph: InfraGraph, params: dict) -> float:
     return min(100.0, (coverage / min_percent) * 100.0)
 
 
-def _check_cb_coverage(graph: InfraGraph, params: dict) -> float:
+def _check_cb_coverage(graph: InfraGraph, params: CheckParams) -> float:
     """Check percentage of dependency edges with circuit breakers.
 
     Params:
@@ -160,7 +199,7 @@ def _check_cb_coverage(graph: InfraGraph, params: dict) -> float:
     return min(100.0, (coverage / min_percent) * 100.0)
 
 
-def _check_backup_coverage(graph: InfraGraph, params: dict) -> float:
+def _check_backup_coverage(graph: InfraGraph, params: CheckParams) -> float:
     """Check percentage of components with backups enabled.
 
     Params:
@@ -191,7 +230,7 @@ def _check_backup_coverage(graph: InfraGraph, params: dict) -> float:
     return min(100.0, (coverage / min_percent) * 100.0)
 
 
-def _check_max_chain_depth(graph: InfraGraph, params: dict) -> float:
+def _check_max_chain_depth(graph: InfraGraph, params: CheckParams) -> float:
     """Check that the maximum dependency chain depth is under N.
 
     Params:
@@ -215,7 +254,7 @@ def _check_max_chain_depth(graph: InfraGraph, params: dict) -> float:
     return max(0.0, 100.0 - over * 20.0)
 
 
-def _check_no_public_database(graph: InfraGraph, params: dict) -> float:
+def _check_no_public_database(graph: InfraGraph, params: CheckParams) -> float:
     """Check that no database is on a commonly public port.
 
     Params:
@@ -248,29 +287,6 @@ def _check_no_public_database(graph: InfraGraph, params: dict) -> float:
 
 
 # ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _filter_components_by_type(
-    graph: InfraGraph, comp_type_str: str
-) -> list:
-    """Filter components by type string (case-insensitive)."""
-    if not comp_type_str:
-        return list(graph.components.values())
-
-    try:
-        comp_type = ComponentType(comp_type_str.lower())
-    except ValueError:
-        logger.warning("Unknown component type '%s', returning empty list", comp_type_str)
-        return []
-
-    return [
-        c for c in graph.components.values()
-        if c.type == comp_type
-    ]
-
-
-# ---------------------------------------------------------------------------
 # Custom Scoring Engine
 # ---------------------------------------------------------------------------
 
@@ -281,7 +297,7 @@ class CustomScoringEngine:
     check functions or user-provided callables.
     """
 
-    BUILT_IN_CHECKS: dict[str, Callable[[InfraGraph, dict], float]] = {
+    BUILT_IN_CHECKS: dict[str, Callable[[InfraGraph, CheckParams], float]] = {
         "min_replicas": _check_min_replicas,
         "max_utilization": _check_max_utilization,
         "encryption_coverage": _check_encryption_coverage,
@@ -304,7 +320,7 @@ class CustomScoringEngine:
 
     def evaluate(self) -> CustomScoringResult:
         """Evaluate all rules against the graph and compute scores."""
-        rule_results: list[dict] = []
+        rule_results: list[RuleResultRow] = []
         total_weight = 0.0
         weighted_sum = 0.0
 


### PR DESCRIPTION
### **User description**
## Summary
- Add real type annotations (TypedDict + concrete `list[Component]`) to `scoring.py`, `differ.py`, `model/loader.py`, `model/graph.py`
- Wire `mypy --strict` into CI so the core engine stays clean going forward
- Add `types-networkx>=3.0` to the dev dependency group

## Why
mypy --strict on the patent-critical core (scoring/differ/graph/loader) reported 22 errors. The previous CI mypy step ran without `--strict` and only on `src/faultray/model/` with `--ignore-missing-imports`, so these errors were invisible. This PR fixes them and locks the gate.

The interesting part is **not** turning every `dict` into `dict[str, Any]` — that would be theatre. This PR uses real types where the structure is fixed (`RuleResultRow` as a TypedDict, `_filter_components_by_type` returning `list[Component]`) and only keeps `dict[str, Any]` where the input is genuinely dynamic (YAML-loaded `CheckParams`, JSON-loaded simulation results), with comments explaining why.

## Changes
| File | Change |
|------|--------|
| `src/faultray/scoring.py` | `RuleResultRow` TypedDict, `Component` import, `list[Component]` return type, `CheckParams` alias with rationale comment |
| `src/faultray/differ.py` | `ResultDict` / `ScenarioInfo` aliases for the dynamic JSON shapes |
| `src/faultray/model/loader.py` | Parameterise the YAML reader `dict` annotations |
| `src/faultray/model/graph.py` | `_graph: nx.DiGraph[str]` (Component IDs are always `str`) |
| `pyproject.toml` | Add `types-networkx>=3.0` to dev deps |
| `.github/workflows/ci.yml` | New "Type check core engine with mypy --strict" step targeting `model/`, `scoring.py`, `differ.py`. Legacy non-strict step kept during transition. |

## Test plan
- [x] `mypy --strict src/faultray/model/ src/faultray/scoring.py src/faultray/differ.py` → `Success: no issues found in 11 source files`
- [x] `ruff check src/faultray/` → `All checks passed`
- [x] `pytest tests/` → `33134 passed, 10 skipped` (12m36s, 0 failed)
- [ ] CI green on this branch

## Notes for reviewer
- The legacy mypy step in `ci.yml` is intentionally left in place. It runs without `--strict` so it can't regress; it provides a baseline that catches gross errors even if the strict step is skipped or modified.
- `CheckParams = dict[str, Any]` could be tightened with per-check `TypedDict`s in a follow-up, but that requires touching all 8 built-in check functions. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add precise types to core engine
  - Typed scoring rule outputs
  - Typed dynamic JSON and YAML maps
  - Typed `networkx` graph nodes

- Introduce strict mypy CI gate

- Install `types-networkx` for strict checks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  scoring["scoring.py typed params and rule rows"]
  differ["differ.py typed result aliases"]
  model["loader.py and graph.py typed structures"]
  deps["types-networkx dev dependency"]
  ci["CI runs mypy --strict on core engine"]
  scoring -- "validated by" --> ci
  differ -- "validated by" --> ci
  model -- "validated by" --> ci
  deps -- "provides stubs for" --> ci
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scoring.py</strong><dd><code>Stronger typing for scoring engine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/faultray/scoring.py

<ul><li>Add <code>CheckParams</code> alias for YAML-driven checks<br> <li> Introduce <code>RuleResultRow</code> <code>TypedDict</code> for results<br> <li> Return <code>list[Component]</code> from type filtering helper<br> <li> Tighten built-in check and result annotations</ul>


</details>


  </td>
  <td><a href="https://github.com/mattyopon/faultray/pull/27/files#diff-4d029d3362044b8b24f8f765a71071c810beb5162a711bc10f9d0fbf999a695b">+53/-37</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>differ.py</strong><dd><code>Type aliases for simulation diff data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/faultray/differ.py

<ul><li>Import <code>Any</code> for dynamic JSON typing<br> <li> Add <code>ScenarioInfo</code> and <code>ResultDict</code> aliases<br> <li> Annotate diff helpers with typed result maps</ul>


</details>


  </td>
  <td><a href="https://github.com/mattyopon/faultray/pull/27/files#diff-5afdb5acafcebe14636ba7a8b0edd1014b7ead4d676ad4e4fe47a7eee27385d3">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>loader.py</strong><dd><code>Parameterize YAML loader dictionary types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/faultray/model/loader.py

<ul><li>Import <code>Any</code> for YAML-loaded structures<br> <li> Parameterize schema version input as <code>dict[str, Any]</code><br> <li> Type operational config return value and local map</ul>


</details>


  </td>
  <td><a href="https://github.com/mattyopon/faultray/pull/27/files#diff-61b794b11e6ebea5460798b227a419b7d10233351b1b9e445e13cacbad6bf952">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>graph.py</strong><dd><code>Explicit node typing for infrastructure graph</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/faultray/model/graph.py

<ul><li>Annotate internal <code>networkx</code> graph as <code>nx.DiGraph[str]</code><br> <li> Make component ID node typing explicit</ul>


</details>


  </td>
  <td><a href="https://github.com/mattyopon/faultray/pull/27/files#diff-a7da1e69b7901f855fd6777c46bcf6d41323f7436f56c0292139b117a44302f1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Enforce strict mypy in CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Add dedicated <code>mypy --strict</code> CI step<br> <li> Check <code>model/</code>, <code>scoring.py</code>, and <code>differ.py</code><br> <li> Install required typing stubs in workflow</ul>


</details>


  </td>
  <td><a href="https://github.com/mattyopon/faultray/pull/27/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Add networkx type stubs dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<ul><li>Add <code>types-networkx>=3.0</code> to dev dependencies<br> <li> Support strict typing for graph annotations</ul>


</details>


  </td>
  <td><a href="https://github.com/mattyopon/faultray/pull/27/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced type safety across the codebase by introducing comprehensive type annotations and type aliases.
  * Added strict mypy type checking to CI pipeline for additional code targets.
  * Added networkx type stubs as a development dependency to support improved type checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->