### PR TITLE
fix(tf-check): gate on recommendation=high risk in --fail-on-regression

### DIFF
--- a/docs/phase0-validation-report.md
+++ b/docs/phase0-validation-report.md
@@ -11,6 +11,42 @@ Judgement legend:
 - △ — partially verified, or verified with caveats worth documenting.
 - ✗ — failed / not verified.
 
+---
+
+## Correction (2026-04-17, post-Phase-0 re-verification)
+
+⚠️ Two of the three "broken CI/CD exit gate" findings in this report
+(Task 4 and part of the Summary) were **false positives caused by a shell
+pipeline error** during initial verification:
+
+```bash
+# WRONG — echo $? returns tail's exit (always 0), not the CLI's
+python3 -m faultray gate check --before ... --after ... 2>&1 | tail -3
+echo "exit: $?"
+```
+
+Re-verified without the pipe:
+
+| Command | Original claim | Re-verified |
+|---|---|---|
+| `tf-check --fail-on-regression` | ✗ exit 0 on HIGH RISK | ✗ **confirmed bug** (exit 0 — fixed by this PR) |
+| `gate check` | ✗ exit 0 on `passed: false` | ✅ **actually exit 1** (correctly gates) |
+| `gate terraform-plan` | ✗ exit 0 on BLOCKED | ✅ **actually exit 1** (correctly gates) |
+
+Only **`tf-check --fail-on-regression`** is actually broken. The root cause
+is that destructive-only plans (single DB delete) keep `score_delta == 0.0`
+because the simulation has no prior-state model — the ``recommendation``
+engine correctly flags "high risk" via per-resource `risk_level`, but the
+CLI exit logic only checks `score_delta < 0`.
+
+Task 4 judgements below (rows 3–4) remain in the original form for audit
+trail purposes; the correction above supersedes them. Phase 1 Tier 1 scope
+is revised from 3 bugs to 1 bug.
+
+Process lesson: always run `cmd; echo "EXIT=$?"` without a pipe, or use
+`set -o pipefail`. Filed into the memory system as
+`feedback_pipe_exit_code_trap`.
+
 Environment:
 
 - Date: 2026-04-17

--- a/src/faultray/cli/tf_check.py
+++ b/src/faultray/cli/tf_check.py
@@ -142,6 +142,22 @@ def tf_check(
             )
         exit_code = 1
 
+    # Check for high-risk changes flagged by the recommendation engine.
+    # Destructive-only plans (e.g. a single DB delete) often keep
+    # score_before == score_after == 100 because the simulation has no
+    # prior-state model to compare against, so ``score_delta`` never drops
+    # below zero. The ``recommendation`` layer DOES detect the hazard via
+    # per-resource risk_level (aws_db_instance delete → risk 10 →
+    # "high risk"), so gate on it explicitly under --fail-on-regression.
+    if fail_on_regression and analysis.recommendation == "high risk":
+        if not json_output:
+            console.print(
+                f"\n[red]HIGH RISK CHANGE DETECTED: recommendation="
+                f"{analysis.recommendation!r} "
+                f"(resources_destroyed={analysis.resources_destroyed})[/]"
+            )
+        exit_code = 1
+
     # Check minimum score
     if analysis.score_after < min_score:
         if not json_output:

--- a/tests/test_cli_tf_check.py
+++ b/tests/test_cli_tf_check.py
@@ -1,0 +1,112 @@
+"""CLI-level regression tests for ``faultray tf-check``.
+
+Focused on the exit-code contract of ``--fail-on-regression``. The
+documentation promises: "Exit with code 1 if resilience score decreases."
+Phase 0 baseline validation surfaced a case where the gate silently passed
+(exit 0) on a destructive-only plan whose Recommendation was ``"high risk"``
+but whose ``score_delta`` stayed ``0.0`` (the simulation has no prior-state
+model to diff against).
+
+These tests lock the expanded gate contract: ``--fail-on-regression``
+triggers on EITHER a negative score_delta OR a ``recommendation == "high risk"``.
+Reproducer fixture: ``tests/fixtures/sample-tf-plan.json`` (added in PR #66).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SAMPLE_PLAN = REPO_ROOT / "tests" / "fixtures" / "sample-tf-plan.json"
+
+
+def _run_tf_check(*args: str) -> subprocess.CompletedProcess[str]:
+    """Invoke the faultray CLI module directly; preserves its exit code."""
+    return subprocess.run(
+        [sys.executable, "-m", "faultray", "tf-check", *args],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+@pytest.fixture
+def plan_file() -> Path:
+    assert SAMPLE_PLAN.exists(), f"sample plan fixture missing: {SAMPLE_PLAN}"
+    return SAMPLE_PLAN
+
+
+# ---------------------------------------------------------------------------
+# Regression coverage for the Phase 0 finding
+# ---------------------------------------------------------------------------
+
+
+def test_fail_on_regression_fires_for_high_risk_destructive_plan(plan_file: Path) -> None:
+    """``--fail-on-regression`` must exit 1 when the plan is ``high risk``.
+
+    The committed ``sample-tf-plan.json`` contains an ``aws_db_instance.primary``
+    delete (risk_level 10 → recommendation "high risk") but the simulation
+    produces ``score_delta == 0.0`` because there's no prior model to diff.
+    Before the fix, this returned exit 0; after the fix, it returns exit 1
+    via the new recommendation-based gate.
+    """
+    result = _run_tf_check(str(plan_file), "--fail-on-regression")
+    assert result.returncode == 1, (
+        f"expected exit 1 on high-risk plan with --fail-on-regression, "
+        f"got {result.returncode}\nstdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    # The gate should explain *why* it fired.
+    assert "HIGH RISK CHANGE DETECTED" in result.stdout, (
+        f"exit code OK but no explanation printed.\nstdout={result.stdout!r}"
+    )
+
+
+def test_fail_on_regression_still_exits_1_in_json_mode(plan_file: Path) -> None:
+    """--fail-on-regression + --json must still exit 1 on high-risk."""
+    result = _run_tf_check(str(plan_file), "--fail-on-regression", "--json")
+    assert result.returncode == 1
+    # JSON payload must still parse and report recommendation="high risk".
+    # Strip the "FaultRay v... [Free Tier...]" banner line that the CLI
+    # prefixes to stdout before the JSON body.
+    json_blob = "\n".join(
+        ln for ln in result.stdout.splitlines()
+        if not ln.startswith("FaultRay v") and ln.strip()
+    )
+    # The console.print_json output can span multiple lines; find the JSON
+    # object by locating the first "{" and parsing from there.
+    idx = json_blob.index("{")
+    payload = json.loads(json_blob[idx:])
+    assert payload["recommendation"] == "high risk"
+    # score_delta = 0 must NOT alone be enough to pass — the recommendation
+    # layer is now what gates.
+    assert payload["score_delta"] == 0.0
+
+
+def test_no_flag_returns_0_even_on_high_risk(plan_file: Path) -> None:
+    """Without --fail-on-regression, the command is purely informational.
+
+    Even a high-risk recommendation must not flip the exit code: the flag is
+    opt-in, and backwards-compat requires plain ``tf-check`` to stay exit 0.
+    """
+    result = _run_tf_check(str(plan_file))
+    assert result.returncode == 0, (
+        f"expected exit 0 (no flag), got {result.returncode}\n"
+        f"stdout={result.stdout[-400:]!r}"
+    )
+
+
+def test_min_score_threshold_still_fires(plan_file: Path, tmp_path: Path) -> None:
+    """--min-score is an independent gate and must continue to work.
+
+    Using a threshold of 101 forces ``score_after (100.0) < min_score`` and
+    should exit 1 regardless of --fail-on-regression.
+    """
+    result = _run_tf_check(str(plan_file), "--min-score", "101")
+    assert result.returncode == 1
+    assert "POLICY VIOLATION" in result.stdout


### PR DESCRIPTION
## Summary
Fix the Phase 1 Tier 1 bug surfaced in the Phase 0 baseline validation: `tf-check --fail-on-regression` silently exits 0 on destructive-only plans (e.g. a single aws_db_instance.primary delete) even when the recommendation engine has already flagged them as `high risk`.

Also **corrects a self-reported false positive** in the Phase 0 report: `gate check` and `gate terraform-plan` are actually fine. All three were originally claimed broken because the verification step used `| tail -3; echo $?` which returns tail's exit code, not the CLI's. Re-verified without the pipe, only tf-check is broken.

Phase 1 Tier 1 scope: **3 bugs → 1 bug**.

## Root cause (tf-check)

- `analyze_plan()` computes score_before and score_after by simulating two InfraGraphs.
- For destructive-only plans, there is no prior-state model to diff against, so both scores return 100.0 and score_delta = 0.0.
- The recommendation engine correctly returns "high risk" (aws_db_instance delete with risk_level 10 crosses the threshold of 8).
- But the CLI exit code logic in src/faultray/cli/tf_check.py:136-143 only checked `score_delta < 0`, missing the recommendation signal.

## Fix

One new gate clause in `tf_check.py`:

```python
if fail_on_regression and analysis.recommendation == "high risk":
    console.print(
        f"\n[red]HIGH RISK CHANGE DETECTED: recommendation="
        f"{analysis.recommendation!r} "
        f"(resources_destroyed={analysis.resources_destroyed})[/]"
    )
    exit_code = 1
```

## Regression tests

`tests/test_cli_tf_check.py` — 4 CLI-level tests that invoke `python -m faultray tf-check` as a subprocess and assert returncode. Fixture: `tests/fixtures/sample-tf-plan.json` (reused from PR #66, Phase 0 Task 3).

Tests:
1. `test_fail_on_regression_fires_for_high_risk_destructive_plan` — the regression: exit 1 required.
2. `test_fail_on_regression_still_exits_1_in_json_mode` — same with --json.
3. `test_no_flag_returns_0_even_on_high_risk` — backwards compat: no flag means exit 0.
4. `test_min_score_threshold_still_fires` — independent --min-score gate still works.

All 4 pass locally.

## Phase 0 report correction

`docs/phase0-validation-report.md` now has a top-level Correction section:
- Re-verified table showing gate check and gate terraform-plan actually exit 1.
- Process lesson: always run `cmd; echo "EXIT=$?"` without a pipe, or `set -o pipefail`.

Task 4 section body preserved for audit trail.

## Test plan

- [x] `pytest tests/test_cli_tf_check.py -v` — 4/4 pass
- [x] `pytest tests/test_terraform_provider.py -v` — 13/13 pass (no regression in existing tf-check tests)
- [x] Manual repro:
  - Before fix: `tf-check --fail-on-regression sample.json; echo $?` returns 0
  - After fix:  `tf-check --fail-on-regression sample.json; echo $?` returns 1
- [ ] Full CI matrix (triggered by this PR)

## Risk

Minimal. `--fail-on-regression` is opt-in; plain `tf-check` is unchanged (verified by test 3). Behavior change is narrow: plans previously passing with score_delta 0 AND recommendation high risk now correctly fail.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray/pull/68" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
