### PR TITLE
feat(k8s-scanner): infer east/west HTTP edges + attach service ports

### DIFF
--- a/src/faultray/discovery/k8s_scanner.py
+++ b/src/faultray/discovery/k8s_scanner.py
@@ -77,6 +77,11 @@ class K8sScanner:
         self._warnings: list[str] = []
         # Service selector tracking: service_comp_id -> selector labels
         self._service_selectors: dict[str, dict[str, str]] = {}
+        # Service port tracking: service_comp_id -> exposed port (first entry of spec.ports)
+        # Used by _infer_dependencies to attach accurate port/protocol to edges
+        # and to distinguish front-end (80/443) vs back-end ports for
+        # east/west HTTP-tier dependency inference.
+        self._service_ports: dict[str, int] = {}
         # Deployment/StatefulSet label tracking: comp_id -> labels
         self._workload_labels: dict[str, dict[str, str]] = {}
         # HPA targets: comp_id -> AutoScalingConfig
@@ -281,9 +286,12 @@ class K8sScanner:
                 svc_comp_id = f"svc-{ns}-{name}"
                 self._service_selectors[svc_comp_id] = selector
 
-                # Determine port
+                # Capture the first exposed port so _infer_dependencies can
+                # (1) attach it to the generated edge and
+                # (2) decide whether the service is a front-end (80/443) or
+                #     back-end (8080/8443/3000/...) for east/west inference.
                 if svc.spec.ports:
-                    svc.spec.ports[0].port or 0
+                    self._service_ports[svc_comp_id] = svc.spec.ports[0].port or 0
         except Exception as exc:
             self._warnings.append(f"Service scan error: {exc}")
 
@@ -487,8 +495,38 @@ class K8sScanner:
 
     # ── Dependency Inference ─────────────────────────────────────────────────
 
+    # Common back-end HTTP service ports. A workload whose exposing Service
+    # listens on one of these is assumed to be a callable HTTP back-end; other
+    # same-namespace workloads that aren't already classified as its source
+    # (ingress/front-end) become candidate callers. This lets us infer
+    # nginx -> app style east/west edges that the old DB/CACHE-only filter
+    # missed (see Phase 0 validation report, 2026-04-17 §K8s Discovery).
+    #
+    # Intentionally excludes 80/443 so we don't flip the direction — a service
+    # on :80 is a front-end and should not be a *target* of another app_server.
+    _BACKEND_HTTP_PORTS: frozenset[int] = frozenset({
+        3000,   # Node/Express/Next.js
+        5000,   # Flask/Python default
+        8000,   # Django/Python default
+        8080,   # Tomcat/generic alt-http
+        8443,   # Generic alt-https
+        9000,   # PHP-FPM, Sonarqube
+        9090,   # Prometheus
+    })
+
     def _infer_dependencies(self, graph: InfraGraph) -> None:
-        """Infer dependencies from service selectors and network policies."""
+        """Infer dependencies from service selectors and network policies.
+
+        Edge-inference rules (applied per Service):
+        1. **Ingress → backing workload** (HTTP on :80, or :443 if TLS).
+        2. **Same-ns workload → backing workload** when the backing workload
+           is a DATABASE or CACHE (the original DB-heuristic rule).
+        3. **Same-ns workload → backing workload** when the backing Service
+           exposes a back-end HTTP port (see ``_BACKEND_HTTP_PORTS``). This
+           is the east/west HTTP-tier rule; it infers nginx→app without
+           emitting the reverse app→nginx (nginx's Service is on :80 so
+           it fails rule 3 when we'd try to use it as a target).
+        """
         existing_edges: set[tuple[str, str]] = set()
 
         # Match services to workloads via label selectors, then create edges
@@ -510,8 +548,9 @@ class K8sScanner:
             if len(parts) < 3:
                 continue
             svc_ns = parts[1]
+            svc_port = self._service_ports.get(svc_comp_id, 0)
 
-            # Create edges from ingress to matching workloads
+            # Rule 1 — Ingress → matching workloads
             for comp_id in graph.components:
                 if not comp_id.startswith("ingress-"):
                     continue
@@ -530,12 +569,11 @@ class K8sScanner:
                         target_id=workload_id,
                         dependency_type="requires",
                         protocol="http",
-                        port=80,
+                        port=svc_port if svc_port else 80,
                     )
                     graph.add_dependency(dep)
 
-            # Create inter-workload edges: if workload A is in same namespace and
-            # references a service whose selector matches workload B
+            # Rules 2 & 3 — inter-workload edges in the same namespace.
             for other_comp_id in graph.components:
                 if other_comp_id.startswith("ingress-"):
                     continue
@@ -553,15 +591,37 @@ class K8sScanner:
                     edge_key = (other_comp_id, workload_id)
                     if edge_key in existing_edges:
                         continue
-                    # Only create if the target is a database or cache (likely dependency)
                     target_comp = graph.get_component(workload_id)
-                    if target_comp and target_comp.type in (ComponentType.DATABASE, ComponentType.CACHE):
+                    if target_comp is None:
+                        continue
+
+                    # Rule 2 — database/cache targets (original behaviour)
+                    if target_comp.type in (ComponentType.DATABASE, ComponentType.CACHE):
                         existing_edges.add(edge_key)
                         dep = Dependency(
                             source_id=other_comp_id,
                             target_id=workload_id,
                             dependency_type="requires",
                             protocol="tcp",
-                            port=target_comp.port if target_comp.port else 0,
+                            port=svc_port if svc_port else (
+                                target_comp.port if target_comp.port else 0
+                            ),
+                        )
+                        graph.add_dependency(dep)
+                        continue
+
+                    # Rule 3 — east/west HTTP tier: app_server → app_server
+                    # iff the backing Service exposes a back-end port.
+                    if (
+                        target_comp.type == ComponentType.APP_SERVER
+                        and svc_port in self._BACKEND_HTTP_PORTS
+                    ):
+                        existing_edges.add(edge_key)
+                        dep = Dependency(
+                            source_id=other_comp_id,
+                            target_id=workload_id,
+                            dependency_type="requires",
+                            protocol="http",
+                            port=svc_port,
                         )
                         graph.add_dependency(dep)

--- a/tests/test_k8s_scanner.py
+++ b/tests/test_k8s_scanner.py
@@ -702,6 +702,168 @@ class TestDependencyInference:
         )
         assert found
 
+    # ------------------------------------------------------------------
+    # Phase 1 Tier 3: east/west HTTP-tier inference (nginx -> app edge).
+    # ------------------------------------------------------------------
+
+    def test_eastwest_edge_created_when_target_service_uses_backend_port(self):
+        """app_server -> app_server edge created when target Service is on 8080.
+
+        Mirrors the Phase 0 kind-cluster topology (nginx :80, app :8080,
+        redis :6379). Before Phase 1 Tier 3 the scanner only emitted
+        nginx->redis and app->redis. It now also emits nginx->app because
+        app's Service exposes 8080 (a back-end port in BACKEND_HTTP_PORTS).
+        """
+        scanner = _make_scanner()
+        graph = InfraGraph()
+
+        from faultray.model.components import Component
+
+        nginx = Component(
+            id="deploy-demo-nginx", name="demo/nginx",
+            type=ComponentType.APP_SERVER, tags=["deployment", "namespace:demo"]
+        )
+        app = Component(
+            id="deploy-demo-app", name="demo/app",
+            type=ComponentType.APP_SERVER, tags=["deployment", "namespace:demo"]
+        )
+        graph.add_component(nginx)
+        graph.add_component(app)
+
+        scanner._service_selectors = {
+            "svc-demo-nginx": {"app": "nginx"},
+            "svc-demo-app":   {"app": "app"},
+        }
+        scanner._service_ports = {
+            "svc-demo-nginx": 80,    # front-end: NOT a valid east/west target
+            "svc-demo-app":   8080,  # back-end:  IS a valid east/west target
+        }
+        scanner._workload_labels = {
+            "deploy-demo-nginx": {"app": "nginx"},
+            "deploy-demo-app":   {"app": "app"},
+        }
+
+        scanner._infer_dependencies(graph)
+
+        edges = graph.all_dependency_edges()
+
+        # Forward edge (nginx -> app) must be created.
+        nginx_to_app = [
+            e for e in edges
+            if e.source_id == "deploy-demo-nginx"
+            and e.target_id == "deploy-demo-app"
+        ]
+        assert len(nginx_to_app) == 1, (
+            f"expected 1 nginx->app edge, got {len(nginx_to_app)} "
+            f"(all edges: {[(e.source_id, e.target_id) for e in edges]})"
+        )
+        # Port must now be plumbed through, not 0 as in Phase 0.
+        assert nginx_to_app[0].port == 8080
+        assert nginx_to_app[0].protocol == "http"
+
+        # Reverse edge (app -> nginx) must NOT be created — nginx's Service
+        # is on :80 (front-end port), so it fails the back-end-port filter.
+        app_to_nginx = [
+            e for e in edges
+            if e.source_id == "deploy-demo-app"
+            and e.target_id == "deploy-demo-nginx"
+        ]
+        assert app_to_nginx == [], (
+            f"expected no app->nginx edge (nginx is on :80, a front-end port), "
+            f"got {len(app_to_nginx)}: {[(e.source_id, e.target_id) for e in app_to_nginx]}"
+        )
+
+    def test_no_eastwest_edge_when_both_services_on_frontend_ports(self):
+        """Two app_servers both on :80 must NOT generate any east/west edge."""
+        scanner = _make_scanner()
+        graph = InfraGraph()
+
+        from faultray.model.components import Component
+
+        a = Component(
+            id="deploy-demo-a", name="demo/a",
+            type=ComponentType.APP_SERVER, tags=["deployment", "namespace:demo"]
+        )
+        b = Component(
+            id="deploy-demo-b", name="demo/b",
+            type=ComponentType.APP_SERVER, tags=["deployment", "namespace:demo"]
+        )
+        graph.add_component(a)
+        graph.add_component(b)
+
+        scanner._service_selectors = {
+            "svc-demo-a": {"app": "a"},
+            "svc-demo-b": {"app": "b"},
+        }
+        scanner._service_ports = {
+            "svc-demo-a": 80,
+            "svc-demo-b": 443,
+        }
+        scanner._workload_labels = {
+            "deploy-demo-a": {"app": "a"},
+            "deploy-demo-b": {"app": "b"},
+        }
+
+        scanner._infer_dependencies(graph)
+
+        edges = graph.all_dependency_edges()
+        eastwest = [
+            e for e in edges
+            if (e.source_id, e.target_id) in
+               {("deploy-demo-a", "deploy-demo-b"), ("deploy-demo-b", "deploy-demo-a")}
+        ]
+        assert eastwest == [], (
+            f"expected 0 east/west edges (both :80/:443 are front-end), got {eastwest!r}"
+        )
+
+    def test_database_edge_carries_service_port_not_zero(self):
+        """Regression for Phase 0 finding: inferred deps had port=0.
+
+        After this fix, dependency edges into databases use the Service's
+        exposed port (e.g. 6379 for redis) instead of the unpopulated
+        Component.port.
+        """
+        scanner = _make_scanner()
+        graph = InfraGraph()
+
+        from faultray.model.components import Component
+
+        app = Component(
+            id="deploy-demo-app", name="demo/app",
+            type=ComponentType.APP_SERVER, tags=["deployment", "namespace:demo"]
+        )
+        redis = Component(
+            # NOTE: Component.port is intentionally left 0 so we verify
+            # the Service port is what gets wired onto the edge.
+            id="deploy-demo-redis", name="demo/redis",
+            type=ComponentType.DATABASE, tags=["deployment", "namespace:demo"]
+        )
+        graph.add_component(app)
+        graph.add_component(redis)
+
+        scanner._service_selectors = {
+            "svc-demo-redis": {"app": "redis"},
+        }
+        scanner._service_ports = {
+            "svc-demo-redis": 6379,
+        }
+        scanner._workload_labels = {
+            "deploy-demo-app":   {"app": "app"},
+            "deploy-demo-redis": {"app": "redis"},
+        }
+
+        scanner._infer_dependencies(graph)
+
+        edges = [
+            e for e in graph.all_dependency_edges()
+            if e.source_id == "deploy-demo-app"
+            and e.target_id == "deploy-demo-redis"
+        ]
+        assert len(edges) == 1
+        assert edges[0].port == 6379, (
+            f"expected port=6379 from Service spec, got {edges[0].port}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Tests: Full scan integration


### PR DESCRIPTION
## Summary
Phase 1 Tier 3 fix for two k8s-scanner gaps surfaced in the Phase 0 baseline report:

1. **No east/west HTTP edges.** Phase 0 kind topology (nginx + app + redis) produced only nginx→redis and app→redis. The obvious nginx→app edge was missing because the inter-workload rule filtered targets to `(DATABASE, CACHE)` only.
2. **port=0 on every inferred dep.** Scanner read `Service.spec.ports[0].port` then discarded the value (expression not assigned to `self._service_ports`).

## Fix

- New `_service_ports: dict[str, int]` captures each Service port in `_scan_services`.
- `_infer_dependencies` now has three rules:
  1. Ingress → backing workload (port now sourced from Service when available).
  2. Same-ns workload → DATABASE/CACHE backing workload (original rule; port now sourced from Service).
  3. **NEW** Same-ns workload → APP_SERVER backing workload iff the Service is on a back-end port. Frozenset: `{3000, 5000, 8000, 8080, 8443, 9000, 9090}`. Excluding 80/443 prevents flipping direction — a Service on :80 is a front-end and should not be a target.

## Behavior delta (Phase 0 topology)

| Edge | Before | After |
|---|---|---|
| nginx → redis | exists, port=0 | exists, port=6379 |
| app → redis | exists, port=0 | exists, port=6379 |
| nginx → app | missing | **created, port=8080, http** |
| app → nginx | missing | still missing (nginx is :80, front-end) |

## Tests

- 27 existing `test_k8s_scanner.py` tests still pass.
- 3 new regression tests:
  - `test_eastwest_edge_created_when_target_service_uses_backend_port` — reproduces the Phase 0 nginx+app+redis case, asserts port=8080 + no reverse edge
  - `test_no_eastwest_edge_when_both_services_on_frontend_ports` — two workloads both on :80/:443 must NOT generate mutual edges (prevents N² over-inclusion)
  - `test_database_edge_carries_service_port_not_zero` — locks in the port plumbing fix for DB edges

All 30/30 pass locally.

## Risk

Medium-low. Adds edges that were missing; does not change existing DB-heuristic edges semantically. APP_SERVER targets are now included only when the Service is on a back-end port — the port filter bounds the blast radius.

Future extension: NetworkPolicy ingress rules, Endpoints API subset filtering, or OpenTelemetry traces would provide true call-graph evidence beyond this port heuristic.

---
🤖 Generated with Claude Code
