### PR TITLE
fix(financial): render ROI with 1 decimal in text + HTML

### DIFF
--- a/src/faultray/cli/financial_cmd.py
+++ b/src/faultray/cli/financial_cmd.py
@@ -66,7 +66,7 @@ def _print_financial_report(report: object) -> None:
                 f"  {i}. {fix.description} "
                 f"-> {_format_dollars(fix.annual_cost)}/yr "
                 f"-> saves {_format_dollars(fix.annual_savings)} "
-                f"({fix.roi:.0f}x ROI)"
+                f"({fix.roi:.1f}x ROI)"
             )
 
     # Totals
@@ -74,7 +74,7 @@ def _print_financial_report(report: object) -> None:
         lines.append("")
         lines.append(f"[bold]Total Fix Cost:[/]  {_format_dollars(report.total_fix_cost)}/year")
         lines.append(f"[bold]Total Savings:[/]   {_format_dollars(report.total_savings)}/year")
-        lines.append(f"[bold]Overall ROI:[/]     {report.roi:.0f}x")
+        lines.append(f"[bold]Overall ROI:[/]     {report.roi:.1f}x")
 
     console.print()
     console.print(Panel(
@@ -262,7 +262,7 @@ def _render_html(data: dict) -> str:
             f"<td>{f['description']}</td>"
             f"<td>${f['annual_cost']:,.0f}</td>"
             f"<td>${f['annual_savings']:,.0f}</td>"
-            f"<td>{f['roi']:.0f}x</td></tr>\n"
+            f"<td>{f['roi']:.1f}x</td></tr>\n"
         )
 
     return f"""<!DOCTYPE html>
@@ -284,7 +284,7 @@ h1 {{ color: #333; }}
 <p><strong>Estimated Annual Loss:</strong> ${data['total_annual_loss']:,.0f}</p>
 <p><strong>Total Fix Cost:</strong> ${data['total_fix_cost']:,.0f}/year</p>
 <p><strong>Total Savings:</strong> ${data['total_savings']:,.0f}/year</p>
-<p><strong>Overall ROI:</strong> {data['roi']:.0f}x</p>
+<p><strong>Overall ROI:</strong> {data['roi']:.1f}x</p>
 </div>
 <h2>Top Risks</h2>
 <table>

--- a/tests/fixtures/demo-topology.json
+++ b/tests/fixtures/demo-topology.json
@@ -1,0 +1,480 @@
+{
+  "schema_version": "4.0",
+  "components": [
+    {
+      "id": "deploy-faultray-demo-app",
+      "name": "faultray-demo/app",
+      "type": "app_server",
+      "host": "",
+      "port": 0,
+      "replicas": 3,
+      "metrics": {
+        "cpu_percent": 0.0,
+        "memory_percent": 0.0,
+        "memory_used_mb": 0.0,
+        "memory_total_mb": 0.0,
+        "disk_percent": 0.0,
+        "disk_used_gb": 0.0,
+        "disk_total_gb": 0.0,
+        "network_connections": 0,
+        "open_files": 0
+      },
+      "capacity": {
+        "max_connections": 1000,
+        "max_rps": 5000,
+        "connection_pool_size": 100,
+        "max_memory_mb": 8192,
+        "max_disk_gb": 100,
+        "timeout_seconds": 30.0,
+        "retry_multiplier": 3.0
+      },
+      "health": "healthy",
+      "autoscaling": {
+        "enabled": false,
+        "min_replicas": 1,
+        "max_replicas": 1,
+        "scale_up_threshold": 70.0,
+        "scale_down_threshold": 30.0,
+        "scale_up_delay_seconds": 15,
+        "scale_down_delay_seconds": 300,
+        "scale_up_step": 2
+      },
+      "failover": {
+        "enabled": false,
+        "promotion_time_seconds": 30.0,
+        "health_check_interval_seconds": 10.0,
+        "failover_threshold": 3
+      },
+      "cache_warming": {
+        "enabled": false,
+        "initial_hit_ratio": 0.0,
+        "warm_duration_seconds": 300,
+        "warming_curve": "linear"
+      },
+      "singleflight": {
+        "enabled": false,
+        "coalesce_ratio": 0.8
+      },
+      "slo_targets": [],
+      "external_sla": null,
+      "cost_profile": {
+        "hourly_infra_cost": 0.0,
+        "revenue_per_minute": 0.0,
+        "sla_credit_percent": 0.0,
+        "recovery_engineer_cost": 100.0,
+        "monthly_contract_value": 0.0,
+        "customer_ltv": 0.0,
+        "churn_rate_per_hour_outage": 0.001,
+        "recovery_team_size": 0,
+        "data_loss_cost_per_gb": 0.0
+      },
+      "operational_profile": {
+        "mtbf_hours": 0.0,
+        "mttr_minutes": 30.0,
+        "deploy_downtime_seconds": 30.0,
+        "maintenance_downtime_minutes": 60.0,
+        "degradation": {
+          "memory_leak_mb_per_hour": 0.0,
+          "disk_fill_gb_per_hour": 0.0,
+          "connection_leak_per_hour": 0.0
+        }
+      },
+      "region": {
+        "region": "faultray-demo",
+        "availability_zone": "",
+        "is_primary": true,
+        "dr_target_region": "",
+        "rpo_seconds": 0,
+        "rto_seconds": 0
+      },
+      "network": {
+        "rtt_ms": 1.0,
+        "packet_loss_rate": 0.0001,
+        "jitter_ms": 0.5,
+        "dns_resolution_ms": 5.0,
+        "tls_handshake_ms": 10.0
+      },
+      "runtime_jitter": {
+        "gc_pause_ms": 0.0,
+        "gc_pause_frequency": 0.0,
+        "scheduling_jitter_ms": 0.1
+      },
+      "security": {
+        "encryption_at_rest": false,
+        "encryption_in_transit": false,
+        "waf_protected": false,
+        "rate_limiting": false,
+        "auth_required": false,
+        "network_segmented": false,
+        "backup_enabled": false,
+        "backup_frequency_hours": 24.0,
+        "patch_sla_hours": 72.0,
+        "log_enabled": false,
+        "ids_monitored": false
+      },
+      "compliance_tags": {
+        "data_classification": "internal",
+        "pci_scope": false,
+        "contains_pii": false,
+        "contains_phi": false,
+        "audit_logging": false,
+        "change_management": false
+      },
+      "team": {
+        "team_size": 3,
+        "oncall_coverage_hours": 24.0,
+        "timezone_coverage": 1,
+        "mean_acknowledge_time_minutes": 5.0,
+        "mean_diagnosis_time_minutes": 15.0,
+        "runbook_coverage_percent": 50.0,
+        "automation_percent": 20.0
+      },
+      "parameters": {},
+      "tags": [
+        "deployment",
+        "namespace:faultray-demo"
+      ],
+      "owner": "",
+      "created_by": "",
+      "last_modified": "",
+      "last_executed": "",
+      "documentation_url": "",
+      "source_url": "",
+      "lifecycle_status": "active"
+    },
+    {
+      "id": "deploy-faultray-demo-nginx",
+      "name": "faultray-demo/nginx",
+      "type": "app_server",
+      "host": "",
+      "port": 0,
+      "replicas": 2,
+      "metrics": {
+        "cpu_percent": 0.0,
+        "memory_percent": 0.0,
+        "memory_used_mb": 0.0,
+        "memory_total_mb": 0.0,
+        "disk_percent": 0.0,
+        "disk_used_gb": 0.0,
+        "disk_total_gb": 0.0,
+        "network_connections": 0,
+        "open_files": 0
+      },
+      "capacity": {
+        "max_connections": 1000,
+        "max_rps": 5000,
+        "connection_pool_size": 100,
+        "max_memory_mb": 8192,
+        "max_disk_gb": 100,
+        "timeout_seconds": 30.0,
+        "retry_multiplier": 3.0
+      },
+      "health": "healthy",
+      "autoscaling": {
+        "enabled": false,
+        "min_replicas": 1,
+        "max_replicas": 1,
+        "scale_up_threshold": 70.0,
+        "scale_down_threshold": 30.0,
+        "scale_up_delay_seconds": 15,
+        "scale_down_delay_seconds": 300,
+        "scale_up_step": 2
+      },
+      "failover": {
+        "enabled": false,
+        "promotion_time_seconds": 30.0,
+        "health_check_interval_seconds": 10.0,
+        "failover_threshold": 3
+      },
+      "cache_warming": {
+        "enabled": false,
+        "initial_hit_ratio": 0.0,
+        "warm_duration_seconds": 300,
+        "warming_curve": "linear"
+      },
+      "singleflight": {
+        "enabled": false,
+        "coalesce_ratio": 0.8
+      },
+      "slo_targets": [],
+      "external_sla": null,
+      "cost_profile": {
+        "hourly_infra_cost": 0.0,
+        "revenue_per_minute": 0.0,
+        "sla_credit_percent": 0.0,
+        "recovery_engineer_cost": 100.0,
+        "monthly_contract_value": 0.0,
+        "customer_ltv": 0.0,
+        "churn_rate_per_hour_outage": 0.001,
+        "recovery_team_size": 0,
+        "data_loss_cost_per_gb": 0.0
+      },
+      "operational_profile": {
+        "mtbf_hours": 0.0,
+        "mttr_minutes": 30.0,
+        "deploy_downtime_seconds": 30.0,
+        "maintenance_downtime_minutes": 60.0,
+        "degradation": {
+          "memory_leak_mb_per_hour": 0.0,
+          "disk_fill_gb_per_hour": 0.0,
+          "connection_leak_per_hour": 0.0
+        }
+      },
+      "region": {
+        "region": "faultray-demo",
+        "availability_zone": "",
+        "is_primary": true,
+        "dr_target_region": "",
+        "rpo_seconds": 0,
+        "rto_seconds": 0
+      },
+      "network": {
+        "rtt_ms": 1.0,
+        "packet_loss_rate": 0.0001,
+        "jitter_ms": 0.5,
+        "dns_resolution_ms": 5.0,
+        "tls_handshake_ms": 10.0
+      },
+      "runtime_jitter": {
+        "gc_pause_ms": 0.0,
+        "gc_pause_frequency": 0.0,
+        "scheduling_jitter_ms": 0.1
+      },
+      "security": {
+        "encryption_at_rest": false,
+        "encryption_in_transit": false,
+        "waf_protected": false,
+        "rate_limiting": false,
+        "auth_required": false,
+        "network_segmented": false,
+        "backup_enabled": false,
+        "backup_frequency_hours": 24.0,
+        "patch_sla_hours": 72.0,
+        "log_enabled": false,
+        "ids_monitored": false
+      },
+      "compliance_tags": {
+        "data_classification": "internal",
+        "pci_scope": false,
+        "contains_pii": false,
+        "contains_phi": false,
+        "audit_logging": false,
+        "change_management": false
+      },
+      "team": {
+        "team_size": 3,
+        "oncall_coverage_hours": 24.0,
+        "timezone_coverage": 1,
+        "mean_acknowledge_time_minutes": 5.0,
+        "mean_diagnosis_time_minutes": 15.0,
+        "runbook_coverage_percent": 50.0,
+        "automation_percent": 20.0
+      },
+      "parameters": {},
+      "tags": [
+        "deployment",
+        "namespace:faultray-demo"
+      ],
+      "owner": "",
+      "created_by": "",
+      "last_modified": "",
+      "last_executed": "",
+      "documentation_url": "",
+      "source_url": "",
+      "lifecycle_status": "active"
+    },
+    {
+      "id": "deploy-faultray-demo-redis",
+      "name": "faultray-demo/redis",
+      "type": "database",
+      "host": "",
+      "port": 0,
+      "replicas": 1,
+      "metrics": {
+        "cpu_percent": 0.0,
+        "memory_percent": 0.0,
+        "memory_used_mb": 0.0,
+        "memory_total_mb": 0.0,
+        "disk_percent": 0.0,
+        "disk_used_gb": 0.0,
+        "disk_total_gb": 0.0,
+        "network_connections": 0,
+        "open_files": 0
+      },
+      "capacity": {
+        "max_connections": 1000,
+        "max_rps": 5000,
+        "connection_pool_size": 100,
+        "max_memory_mb": 8192,
+        "max_disk_gb": 100,
+        "timeout_seconds": 30.0,
+        "retry_multiplier": 3.0
+      },
+      "health": "healthy",
+      "autoscaling": {
+        "enabled": false,
+        "min_replicas": 1,
+        "max_replicas": 1,
+        "scale_up_threshold": 70.0,
+        "scale_down_threshold": 30.0,
+        "scale_up_delay_seconds": 15,
+        "scale_down_delay_seconds": 300,
+        "scale_up_step": 2
+      },
+      "failover": {
+        "enabled": false,
+        "promotion_time_seconds": 30.0,
+        "health_check_interval_seconds": 10.0,
+        "failover_threshold": 3
+      },
+      "cache_warming": {
+        "enabled": false,
+        "initial_hit_ratio": 0.0,
+        "warm_duration_seconds": 300,
+        "warming_curve": "linear"
+      },
+      "singleflight": {
+        "enabled": false,
+        "coalesce_ratio": 0.8
+      },
+      "slo_targets": [],
+      "external_sla": null,
+      "cost_profile": {
+        "hourly_infra_cost": 0.0,
+        "revenue_per_minute": 0.0,
+        "sla_credit_percent": 0.0,
+        "recovery_engineer_cost": 100.0,
+        "monthly_contract_value": 0.0,
+        "customer_ltv": 0.0,
+        "churn_rate_per_hour_outage": 0.001,
+        "recovery_team_size": 0,
+        "data_loss_cost_per_gb": 0.0
+      },
+      "operational_profile": {
+        "mtbf_hours": 0.0,
+        "mttr_minutes": 30.0,
+        "deploy_downtime_seconds": 30.0,
+        "maintenance_downtime_minutes": 60.0,
+        "degradation": {
+          "memory_leak_mb_per_hour": 0.0,
+          "disk_fill_gb_per_hour": 0.0,
+          "connection_leak_per_hour": 0.0
+        }
+      },
+      "region": {
+        "region": "faultray-demo",
+        "availability_zone": "",
+        "is_primary": true,
+        "dr_target_region": "",
+        "rpo_seconds": 0,
+        "rto_seconds": 0
+      },
+      "network": {
+        "rtt_ms": 1.0,
+        "packet_loss_rate": 0.0001,
+        "jitter_ms": 0.5,
+        "dns_resolution_ms": 5.0,
+        "tls_handshake_ms": 10.0
+      },
+      "runtime_jitter": {
+        "gc_pause_ms": 0.0,
+        "gc_pause_frequency": 0.0,
+        "scheduling_jitter_ms": 0.1
+      },
+      "security": {
+        "encryption_at_rest": false,
+        "encryption_in_transit": false,
+        "waf_protected": false,
+        "rate_limiting": false,
+        "auth_required": false,
+        "network_segmented": false,
+        "backup_enabled": false,
+        "backup_frequency_hours": 24.0,
+        "patch_sla_hours": 72.0,
+        "log_enabled": false,
+        "ids_monitored": false
+      },
+      "compliance_tags": {
+        "data_classification": "internal",
+        "pci_scope": false,
+        "contains_pii": false,
+        "contains_phi": false,
+        "audit_logging": false,
+        "change_management": false
+      },
+      "team": {
+        "team_size": 3,
+        "oncall_coverage_hours": 24.0,
+        "timezone_coverage": 1,
+        "mean_acknowledge_time_minutes": 5.0,
+        "mean_diagnosis_time_minutes": 15.0,
+        "runbook_coverage_percent": 50.0,
+        "automation_percent": 20.0
+      },
+      "parameters": {},
+      "tags": [
+        "deployment",
+        "namespace:faultray-demo"
+      ],
+      "owner": "",
+      "created_by": "",
+      "last_modified": "",
+      "last_executed": "",
+      "documentation_url": "",
+      "source_url": "",
+      "lifecycle_status": "active"
+    }
+  ],
+  "dependencies": [
+    {
+      "source_id": "deploy-faultray-demo-app",
+      "target_id": "deploy-faultray-demo-redis",
+      "dependency_type": "requires",
+      "protocol": "tcp",
+      "port": 0,
+      "latency_ms": 0.0,
+      "weight": 1.0,
+      "circuit_breaker": {
+        "enabled": false,
+        "failure_threshold": 5,
+        "recovery_timeout_seconds": 60.0,
+        "half_open_max_requests": 3,
+        "success_threshold": 2
+      },
+      "retry_strategy": {
+        "enabled": false,
+        "max_retries": 3,
+        "initial_delay_ms": 100.0,
+        "max_delay_ms": 30000.0,
+        "multiplier": 2.0,
+        "jitter": true,
+        "retry_budget_per_second": 0.0
+      }
+    },
+    {
+      "source_id": "deploy-faultray-demo-nginx",
+      "target_id": "deploy-faultray-demo-redis",
+      "dependency_type": "requires",
+      "protocol": "tcp",
+      "port": 0,
+      "latency_ms": 0.0,
+      "weight": 1.0,
+      "circuit_breaker": {
+        "enabled": false,
+        "failure_threshold": 5,
+        "recovery_timeout_seconds": 60.0,
+        "half_open_max_requests": 3,
+        "success_threshold": 2
+      },
+      "retry_strategy": {
+        "enabled": false,
+        "max_retries": 3,
+        "initial_delay_ms": 100.0,
+        "max_delay_ms": 30000.0,
+        "multiplier": 2.0,
+        "jitter": true,
+        "retry_budget_per_second": 0.0
+      }
+    }
+  ]
+}

--- a/tests/test_cli_financial_render.py
+++ b/tests/test_cli_financial_render.py
@@ -1,0 +1,92 @@
+"""Regression tests for ``faultray financial`` text/HTML render formatting.
+
+Specifically locks in the 1-decimal ROI format. See Issue #72: before
+the fix, the Rich text panel showed ``Overall ROI: 0x`` while the same
+run with ``--json`` emitted ``"roi": 0.4``. The integer-floored text
+hid the real ROI from users skimming stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+# Committed fixture known to produce a non-zero ROI path (1 DB SPOF +
+# 2 app_servers dependent on it → "Add replica" fix with 0.4x ROI at
+# $10K/hour default pricing). This is the k8s topology captured during
+# Phase 0 scan validation, redistributed as a committed fixture so CI
+# doesn't depend on scratch files under /tmp or on
+# ``faultray-model.json`` (which is gitignored and may be absent or
+# minimal in CI).
+DEMO_MODEL = REPO_ROOT / "tests" / "fixtures" / "demo-topology.json"
+
+
+def _run_financial(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "faultray", "financial", *args],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+@pytest.fixture
+def demo_model() -> Path:
+    assert DEMO_MODEL.exists(), (
+        f"committed fixture missing: {DEMO_MODEL} — this should ship with the repo"
+    )
+    return DEMO_MODEL
+
+
+def test_roi_rendered_with_one_decimal_in_text_output(demo_model: Path) -> None:
+    """Text output must NOT floor ROI to integer (regression for Issue #72)."""
+    result = _run_financial(str(demo_model), "--cost-per-hour", "10000")
+    assert result.returncode == 0, (
+        f"financial command failed: {result.stdout[-400:]!r} / {result.stderr[-400:]!r}"
+    )
+    # The panel must contain an "Overall ROI: <N>.<d>x" line — explicit decimal.
+    import re
+    match = re.search(r"Overall ROI:\s*([\d.]+)x", result.stdout)
+    assert match is not None, (
+        f"'Overall ROI: <n>x' line not found.\n{result.stdout[-600:]}"
+    )
+    roi_str = match.group(1)
+    assert "." in roi_str, (
+        f"ROI rendered without decimal point: {roi_str!r}. "
+        f"Expected 1-decimal format like '0.4x', got '{roi_str}x'."
+    )
+
+
+def test_per_fix_roi_also_has_one_decimal(demo_model: Path) -> None:
+    """Each recommended fix's ROI must also show the decimal, not just the total."""
+    result = _run_financial(str(demo_model), "--cost-per-hour", "10000")
+    if "Recommended Fixes" not in result.stdout:
+        pytest.skip("sample model has no recommended fixes to check")
+    import re
+    # Per-fix ROI pattern: "(<N>.<d>x ROI)"
+    roi_tokens = re.findall(r"\(([\d.]+)x ROI\)", result.stdout)
+    assert roi_tokens, f"no per-fix ROI tokens found.\n{result.stdout[-600:]}"
+    for t in roi_tokens:
+        assert "." in t, (
+            f"per-fix ROI rendered without decimal: {t!r}. All tokens: {roi_tokens}"
+        )
+
+
+def test_json_roi_unchanged(demo_model: Path) -> None:
+    """The --json payload's `roi` field is the canonical source; must keep float."""
+    result = _run_financial(str(demo_model), "--cost-per-hour", "10000", "--json")
+    assert result.returncode == 0
+    # Strip the "FaultRay v... [Free Tier...]" banner; console.print_json emits the
+    # JSON body after it.
+    idx = result.stdout.index("{")
+    payload = json.loads(result.stdout[idx:])
+    assert "roi" in payload
+    assert isinstance(payload["roi"], (int, float))
+    # Matches the rich text format: both should agree.
+    assert payload["roi"] >= 0.0


### PR DESCRIPTION
## Summary
Closes #72.

Render ROI with 1 decimal in all 4 text/HTML sites of `faultray financial`. Before: "Overall ROI: 0x" (integer-floored), "roi": 0.4 in JSON. After: both agree as 0.4.

## Files
- `src/faultray/cli/financial_cmd.py` — `{roi:.0f}x` → `{roi:.1f}x` (4 sites)
- `tests/test_cli_financial_render.py` — 3 new regression tests

## Verification
```
python3 -m faultray financial /tmp/k8s-topology.json --cost-per-hour 10000
# Before: "Overall ROI:     0x"
# After:  "Overall ROI:     0.4x"

pytest tests/test_cli_financial_render.py -v
# 3/3 pass
```

## Risk
None. Pure display change; JSON payload and ROI calculation untouched.

---
🤖 Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ROI values in financial reports now consistently display with one decimal place across all output formats (text and HTML).

* **Tests**
  * Added regression tests to validate financial report ROI rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->