### PR TITLE
fix(financial): stop clipping Component table columns mid-digit

### DIFF
--- a/src/faultray/cli/financial_cmd.py
+++ b/src/faultray/cli/financial_cmd.py
@@ -83,19 +83,28 @@ def _print_financial_report(report: object) -> None:
         border_style=border,
     ))
 
-    # Detailed component table
+    # Detailed component table.
+    #
+    # Earlier versions pinned widths to values summing to >80 cols, so Rich
+    # auto-shrank every cell to 4-5 chars (headers → "$/…", data → "$10,1…").
+    # We now:
+    #   1. let numeric columns size to their content (no_wrap),
+    #   2. allow the long free-form Component id and Risk description to
+    #      wrap (overflow="fold") so they don't eat the whole row,
+    #   3. accept that extremely wide terminals may yield a wider table —
+    #      that is cheap compared to unreadable data.
     if report.component_impacts:
         table = Table(
             title="Component Financial Impact (all components)",
             show_header=True,
         )
-        table.add_column("Component", style="cyan", width=20)
-        table.add_column("Type", width=16)
-        table.add_column("Avail %", justify="right", width=10)
-        table.add_column("Downtime/yr", justify="right", width=12)
-        table.add_column("$/Hour", justify="right", width=10)
-        table.add_column("Loss/yr", justify="right", width=14)
-        table.add_column("Risk", width=30)
+        table.add_column("Component", style="cyan", overflow="fold")
+        table.add_column("Type", no_wrap=True)
+        table.add_column("Avail %", justify="right", no_wrap=True)
+        table.add_column("Downtime/yr", justify="right", no_wrap=True)
+        table.add_column("$/Hour", justify="right", no_wrap=True)
+        table.add_column("Loss/yr", justify="right", no_wrap=True)
+        table.add_column("Risk", overflow="fold")
 
         for impact in report.component_impacts:
             avail_pct = impact.availability * 100
@@ -112,6 +121,9 @@ def _print_financial_report(report: object) -> None:
                 else "dim"
             )
 
+            # Risk description is no longer truncated to 30 chars here —
+            # the column declaration uses overflow="fold" so Rich wraps it
+            # within the cell instead of cutting mid-sentence.
             table.add_row(
                 impact.component_id,
                 impact.component_type,
@@ -119,9 +131,7 @@ def _print_financial_report(report: object) -> None:
                 f"{impact.annual_downtime_hours:.2f}h",
                 f"${impact.cost_per_hour:,.0f}",
                 f"[{loss_color}]${impact.annual_loss:,.0f}[/]",
-                (impact.risk_description[:30]
-                 if len(impact.risk_description) > 30
-                 else impact.risk_description),
+                impact.risk_description,
             )
 
         console.print()

--- a/tests/fixtures/demo-topology.json
+++ b/tests/fixtures/demo-topology.json
@@ -1,0 +1,480 @@
+{
+  "schema_version": "4.0",
+  "components": [
+    {
+      "id": "deploy-faultray-demo-app",
+      "name": "faultray-demo/app",
+      "type": "app_server",
+      "host": "",
+      "port": 0,
+      "replicas": 3,
+      "metrics": {
+        "cpu_percent": 0.0,
+        "memory_percent": 0.0,
+        "memory_used_mb": 0.0,
+        "memory_total_mb": 0.0,
+        "disk_percent": 0.0,
+        "disk_used_gb": 0.0,
+        "disk_total_gb": 0.0,
+        "network_connections": 0,
+        "open_files": 0
+      },
+      "capacity": {
+        "max_connections": 1000,
+        "max_rps": 5000,
+        "connection_pool_size": 100,
+        "max_memory_mb": 8192,
+        "max_disk_gb": 100,
+        "timeout_seconds": 30.0,
+        "retry_multiplier": 3.0
+      },
+      "health": "healthy",
+      "autoscaling": {
+        "enabled": false,
+        "min_replicas": 1,
+        "max_replicas": 1,
+        "scale_up_threshold": 70.0,
+        "scale_down_threshold": 30.0,
+        "scale_up_delay_seconds": 15,
+        "scale_down_delay_seconds": 300,
+        "scale_up_step": 2
+      },
+      "failover": {
+        "enabled": false,
+        "promotion_time_seconds": 30.0,
+        "health_check_interval_seconds": 10.0,
+        "failover_threshold": 3
+      },
+      "cache_warming": {
+        "enabled": false,
+        "initial_hit_ratio": 0.0,
+        "warm_duration_seconds": 300,
+        "warming_curve": "linear"
+      },
+      "singleflight": {
+        "enabled": false,
+        "coalesce_ratio": 0.8
+      },
+      "slo_targets": [],
+      "external_sla": null,
+      "cost_profile": {
+        "hourly_infra_cost": 0.0,
+        "revenue_per_minute": 0.0,
+        "sla_credit_percent": 0.0,
+        "recovery_engineer_cost": 100.0,
+        "monthly_contract_value": 0.0,
+        "customer_ltv": 0.0,
+        "churn_rate_per_hour_outage": 0.001,
+        "recovery_team_size": 0,
+        "data_loss_cost_per_gb": 0.0
+      },
+      "operational_profile": {
+        "mtbf_hours": 0.0,
+        "mttr_minutes": 30.0,
+        "deploy_downtime_seconds": 30.0,
+        "maintenance_downtime_minutes": 60.0,
+        "degradation": {
+          "memory_leak_mb_per_hour": 0.0,
+          "disk_fill_gb_per_hour": 0.0,
+          "connection_leak_per_hour": 0.0
+        }
+      },
+      "region": {
+        "region": "faultray-demo",
+        "availability_zone": "",
+        "is_primary": true,
+        "dr_target_region": "",
+        "rpo_seconds": 0,
+        "rto_seconds": 0
+      },
+      "network": {
+        "rtt_ms": 1.0,
+        "packet_loss_rate": 0.0001,
+        "jitter_ms": 0.5,
+        "dns_resolution_ms": 5.0,
+        "tls_handshake_ms": 10.0
+      },
+      "runtime_jitter": {
+        "gc_pause_ms": 0.0,
+        "gc_pause_frequency": 0.0,
+        "scheduling_jitter_ms": 0.1
+      },
+      "security": {
+        "encryption_at_rest": false,
+        "encryption_in_transit": false,
+        "waf_protected": false,
+        "rate_limiting": false,
+        "auth_required": false,
+        "network_segmented": false,
+        "backup_enabled": false,
+        "backup_frequency_hours": 24.0,
+        "patch_sla_hours": 72.0,
+        "log_enabled": false,
+        "ids_monitored": false
+      },
+      "compliance_tags": {
+        "data_classification": "internal",
+        "pci_scope": false,
+        "contains_pii": false,
+        "contains_phi": false,
+        "audit_logging": false,
+        "change_management": false
+      },
+      "team": {
+        "team_size": 3,
+        "oncall_coverage_hours": 24.0,
+        "timezone_coverage": 1,
+        "mean_acknowledge_time_minutes": 5.0,
+        "mean_diagnosis_time_minutes": 15.0,
+        "runbook_coverage_percent": 50.0,
+        "automation_percent": 20.0
+      },
+      "parameters": {},
+      "tags": [
+        "deployment",
+        "namespace:faultray-demo"
+      ],
+      "owner": "",
+      "created_by": "",
+      "last_modified": "",
+      "last_executed": "",
+      "documentation_url": "",
+      "source_url": "",
+      "lifecycle_status": "active"
+    },
+    {
+      "id": "deploy-faultray-demo-nginx",
+      "name": "faultray-demo/nginx",
+      "type": "app_server",
+      "host": "",
+      "port": 0,
+      "replicas": 2,
+      "metrics": {
+        "cpu_percent": 0.0,
+        "memory_percent": 0.0,
+        "memory_used_mb": 0.0,
+        "memory_total_mb": 0.0,
+        "disk_percent": 0.0,
+        "disk_used_gb": 0.0,
+        "disk_total_gb": 0.0,
+        "network_connections": 0,
+        "open_files": 0
+      },
+      "capacity": {
+        "max_connections": 1000,
+        "max_rps": 5000,
+        "connection_pool_size": 100,
+        "max_memory_mb": 8192,
+        "max_disk_gb": 100,
+        "timeout_seconds": 30.0,
+        "retry_multiplier": 3.0
+      },
+      "health": "healthy",
+      "autoscaling": {
+        "enabled": false,
+        "min_replicas": 1,
+        "max_replicas": 1,
+        "scale_up_threshold": 70.0,
+        "scale_down_threshold": 30.0,
+        "scale_up_delay_seconds": 15,
+        "scale_down_delay_seconds": 300,
+        "scale_up_step": 2
+      },
+      "failover": {
+        "enabled": false,
+        "promotion_time_seconds": 30.0,
+        "health_check_interval_seconds": 10.0,
+        "failover_threshold": 3
+      },
+      "cache_warming": {
+        "enabled": false,
+        "initial_hit_ratio": 0.0,
+        "warm_duration_seconds": 300,
+        "warming_curve": "linear"
+      },
+      "singleflight": {
+        "enabled": false,
+        "coalesce_ratio": 0.8
+      },
+      "slo_targets": [],
+      "external_sla": null,
+      "cost_profile": {
+        "hourly_infra_cost": 0.0,
+        "revenue_per_minute": 0.0,
+        "sla_credit_percent": 0.0,
+        "recovery_engineer_cost": 100.0,
+        "monthly_contract_value": 0.0,
+        "customer_ltv": 0.0,
+        "churn_rate_per_hour_outage": 0.001,
+        "recovery_team_size": 0,
+        "data_loss_cost_per_gb": 0.0
+      },
+      "operational_profile": {
+        "mtbf_hours": 0.0,
+        "mttr_minutes": 30.0,
+        "deploy_downtime_seconds": 30.0,
+        "maintenance_downtime_minutes": 60.0,
+        "degradation": {
+          "memory_leak_mb_per_hour": 0.0,
+          "disk_fill_gb_per_hour": 0.0,
+          "connection_leak_per_hour": 0.0
+        }
+      },
+      "region": {
+        "region": "faultray-demo",
+        "availability_zone": "",
+        "is_primary": true,
+        "dr_target_region": "",
+        "rpo_seconds": 0,
+        "rto_seconds": 0
+      },
+      "network": {
+        "rtt_ms": 1.0,
+        "packet_loss_rate": 0.0001,
+        "jitter_ms": 0.5,
+        "dns_resolution_ms": 5.0,
+        "tls_handshake_ms": 10.0
+      },
+      "runtime_jitter": {
+        "gc_pause_ms": 0.0,
+        "gc_pause_frequency": 0.0,
+        "scheduling_jitter_ms": 0.1
+      },
+      "security": {
+        "encryption_at_rest": false,
+        "encryption_in_transit": false,
+        "waf_protected": false,
+        "rate_limiting": false,
+        "auth_required": false,
+        "network_segmented": false,
+        "backup_enabled": false,
+        "backup_frequency_hours": 24.0,
+        "patch_sla_hours": 72.0,
+        "log_enabled": false,
+        "ids_monitored": false
+      },
+      "compliance_tags": {
+        "data_classification": "internal",
+        "pci_scope": false,
+        "contains_pii": false,
+        "contains_phi": false,
+        "audit_logging": false,
+        "change_management": false
+      },
+      "team": {
+        "team_size": 3,
+        "oncall_coverage_hours": 24.0,
+        "timezone_coverage": 1,
+        "mean_acknowledge_time_minutes": 5.0,
+        "mean_diagnosis_time_minutes": 15.0,
+        "runbook_coverage_percent": 50.0,
+        "automation_percent": 20.0
+      },
+      "parameters": {},
+      "tags": [
+        "deployment",
+        "namespace:faultray-demo"
+      ],
+      "owner": "",
+      "created_by": "",
+      "last_modified": "",
+      "last_executed": "",
+      "documentation_url": "",
+      "source_url": "",
+      "lifecycle_status": "active"
+    },
+    {
+      "id": "deploy-faultray-demo-redis",
+      "name": "faultray-demo/redis",
+      "type": "database",
+      "host": "",
+      "port": 0,
+      "replicas": 1,
+      "metrics": {
+        "cpu_percent": 0.0,
+        "memory_percent": 0.0,
+        "memory_used_mb": 0.0,
+        "memory_total_mb": 0.0,
+        "disk_percent": 0.0,
+        "disk_used_gb": 0.0,
+        "disk_total_gb": 0.0,
+        "network_connections": 0,
+        "open_files": 0
+      },
+      "capacity": {
+        "max_connections": 1000,
+        "max_rps": 5000,
+        "connection_pool_size": 100,
+        "max_memory_mb": 8192,
+        "max_disk_gb": 100,
+        "timeout_seconds": 30.0,
+        "retry_multiplier": 3.0
+      },
+      "health": "healthy",
+      "autoscaling": {
+        "enabled": false,
+        "min_replicas": 1,
+        "max_replicas": 1,
+        "scale_up_threshold": 70.0,
+        "scale_down_threshold": 30.0,
+        "scale_up_delay_seconds": 15,
+        "scale_down_delay_seconds": 300,
+        "scale_up_step": 2
+      },
+      "failover": {
+        "enabled": false,
+        "promotion_time_seconds": 30.0,
+        "health_check_interval_seconds": 10.0,
+        "failover_threshold": 3
+      },
+      "cache_warming": {
+        "enabled": false,
+        "initial_hit_ratio": 0.0,
+        "warm_duration_seconds": 300,
+        "warming_curve": "linear"
+      },
+      "singleflight": {
+        "enabled": false,
+        "coalesce_ratio": 0.8
+      },
+      "slo_targets": [],
+      "external_sla": null,
+      "cost_profile": {
+        "hourly_infra_cost": 0.0,
+        "revenue_per_minute": 0.0,
+        "sla_credit_percent": 0.0,
+        "recovery_engineer_cost": 100.0,
+        "monthly_contract_value": 0.0,
+        "customer_ltv": 0.0,
+        "churn_rate_per_hour_outage": 0.001,
+        "recovery_team_size": 0,
+        "data_loss_cost_per_gb": 0.0
+      },
+      "operational_profile": {
+        "mtbf_hours": 0.0,
+        "mttr_minutes": 30.0,
+        "deploy_downtime_seconds": 30.0,
+        "maintenance_downtime_minutes": 60.0,
+        "degradation": {
+          "memory_leak_mb_per_hour": 0.0,
+          "disk_fill_gb_per_hour": 0.0,
+          "connection_leak_per_hour": 0.0
+        }
+      },
+      "region": {
+        "region": "faultray-demo",
+        "availability_zone": "",
+        "is_primary": true,
+        "dr_target_region": "",
+        "rpo_seconds": 0,
+        "rto_seconds": 0
+      },
+      "network": {
+        "rtt_ms": 1.0,
+        "packet_loss_rate": 0.0001,
+        "jitter_ms": 0.5,
+        "dns_resolution_ms": 5.0,
+        "tls_handshake_ms": 10.0
+      },
+      "runtime_jitter": {
+        "gc_pause_ms": 0.0,
+        "gc_pause_frequency": 0.0,
+        "scheduling_jitter_ms": 0.1
+      },
+      "security": {
+        "encryption_at_rest": false,
+        "encryption_in_transit": false,
+        "waf_protected": false,
+        "rate_limiting": false,
+        "auth_required": false,
+        "network_segmented": false,
+        "backup_enabled": false,
+        "backup_frequency_hours": 24.0,
+        "patch_sla_hours": 72.0,
+        "log_enabled": false,
+        "ids_monitored": false
+      },
+      "compliance_tags": {
+        "data_classification": "internal",
+        "pci_scope": false,
+        "contains_pii": false,
+        "contains_phi": false,
+        "audit_logging": false,
+        "change_management": false
+      },
+      "team": {
+        "team_size": 3,
+        "oncall_coverage_hours": 24.0,
+        "timezone_coverage": 1,
+        "mean_acknowledge_time_minutes": 5.0,
+        "mean_diagnosis_time_minutes": 15.0,
+        "runbook_coverage_percent": 50.0,
+        "automation_percent": 20.0
+      },
+      "parameters": {},
+      "tags": [
+        "deployment",
+        "namespace:faultray-demo"
+      ],
+      "owner": "",
+      "created_by": "",
+      "last_modified": "",
+      "last_executed": "",
+      "documentation_url": "",
+      "source_url": "",
+      "lifecycle_status": "active"
+    }
+  ],
+  "dependencies": [
+    {
+      "source_id": "deploy-faultray-demo-app",
+      "target_id": "deploy-faultray-demo-redis",
+      "dependency_type": "requires",
+      "protocol": "tcp",
+      "port": 0,
+      "latency_ms": 0.0,
+      "weight": 1.0,
+      "circuit_breaker": {
+        "enabled": false,
+        "failure_threshold": 5,
+        "recovery_timeout_seconds": 60.0,
+        "half_open_max_requests": 3,
+        "success_threshold": 2
+      },
+      "retry_strategy": {
+        "enabled": false,
+        "max_retries": 3,
+        "initial_delay_ms": 100.0,
+        "max_delay_ms": 30000.0,
+        "multiplier": 2.0,
+        "jitter": true,
+        "retry_budget_per_second": 0.0
+      }
+    },
+    {
+      "source_id": "deploy-faultray-demo-nginx",
+      "target_id": "deploy-faultray-demo-redis",
+      "dependency_type": "requires",
+      "protocol": "tcp",
+      "port": 0,
+      "latency_ms": 0.0,
+      "weight": 1.0,
+      "circuit_breaker": {
+        "enabled": false,
+        "failure_threshold": 5,
+        "recovery_timeout_seconds": 60.0,
+        "half_open_max_requests": 3,
+        "success_threshold": 2
+      },
+      "retry_strategy": {
+        "enabled": false,
+        "max_retries": 3,
+        "initial_delay_ms": 100.0,
+        "max_delay_ms": 30000.0,
+        "multiplier": 2.0,
+        "jitter": true,
+        "retry_budget_per_second": 0.0
+      }
+    }
+  ]
+}

--- a/tests/test_cli_financial_table.py
+++ b/tests/test_cli_financial_table.py
@@ -1,0 +1,95 @@
+"""Regression tests for the Component Financial Impact Rich Table layout.
+
+See Issue #73: before this fix the table used fixed column widths summing
+to >80 cols, so Rich auto-shrank each cell to 4-5 chars and rendered
+``$/Hour`` as ``$/…``, ``$10,140`` as ``$10,1…``, etc. After the fix,
+letting Rich size to content + ``overflow="fold"`` on free-form cells
+restores full data at normal terminal widths.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+# Committed fixture with 3 components + 2 deps + a DB SPOF so the
+# financial report renders the full Component Table in CI — not just
+# an empty panel when ``faultray-model.json`` is minimal/absent. The
+# fixture file ships in PR #76 (``tests/fixtures/demo-topology.json``);
+# this PR depends on that file being on main.
+DEMO_MODEL = REPO_ROOT / "tests" / "fixtures" / "demo-topology.json"
+
+
+@pytest.fixture
+def demo_model() -> Path:
+    assert DEMO_MODEL.exists(), (
+        f"committed fixture missing: {DEMO_MODEL}"
+    )
+    return DEMO_MODEL
+
+
+def _run_financial_at_width(
+    model: Path, cols: str
+) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env["COLUMNS"] = cols
+    env.setdefault("TERM", "xterm-256color")
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "faultray",
+            "financial",
+            str(model),
+            "--cost-per-hour",
+            "10000",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+    )
+
+
+def test_headers_render_in_full_at_wide_terminal(demo_model: Path) -> None:
+    """At 120 cols, the full header labels must be visible (no ellipsis)."""
+    result = _run_financial_at_width(demo_model, "120")
+    assert result.returncode == 0, result.stderr[-400:]
+    for label in ("Avail %", "Downtime/yr", "$/Hour", "Loss/yr"):
+        assert label in result.stdout, (
+            f"header {label!r} truncated at 120 cols.\n"
+            f"Tail: {result.stdout[-800:]}"
+        )
+
+
+def test_no_values_truncated_mid_digit_at_wide_terminal(demo_model: Path) -> None:
+    """At 120 cols, numeric values must not end in ellipsis mid-number."""
+    result = _run_financial_at_width(demo_model, "120")
+    assert result.returncode == 0
+    # The old bug produced lines like "$10,1…", "$1…" for the Loss column
+    # (money truncated mid-digit after the thousand separator). Assert no
+    # such pattern appears in the body.
+    import re
+
+    bad = re.findall(r"\$[\d,]+…", result.stdout)
+    assert not bad, (
+        f"money values truncated mid-digit: {bad!r}\n"
+        f"Tail: {result.stdout[-800:]}"
+    )
+
+
+def test_table_renders_cleanly_at_narrow_terminal(demo_model: Path) -> None:
+    """At 80 cols the table wraps instead of truncating; no traceback."""
+    result = _run_financial_at_width(demo_model, "80")
+    assert result.returncode == 0, result.stderr[-400:]
+    # Table bottom-border char present.
+    assert "└" in result.stdout
+    # No stack traces.
+    assert "Traceback" not in result.stdout
+    assert "Traceback" not in result.stderr


### PR DESCRIPTION
## Summary
Closes #73.

Before this fix the Rich Table in `faultray financial` used fixed column widths summing to 112 cols. On a standard 80-col terminal Rich auto-shrank each column to 4-5 chars, producing:

```
┃ Component    ┃ Type     ┃  % ┃ Dow… ┃ $/… ┃ Loss/… ┃ Risk                    ┃
│ deploy-faul… │ database │ 9… │ 1.0… │ $1… │ $10,1… │ Single point of failure │
```

Numeric values clipped mid-digit. Headers truncated. Data unreadable.

## Fix
- Remove fixed `width=` from all 7 columns.
- Add `no_wrap=True` on the 5 numeric columns (Type, Avail %, Downtime/yr, $/Hour, Loss/yr) so the content sizes them naturally.
- Use `overflow="fold"` on the 2 free-form columns (Component id, Risk description) so long values wrap across lines instead of being cut.
- Drop the manual `risk_description[:30]` truncation — the column declaration now handles overflow cleanly.

## Behavior

At `COLUMNS=120`:
```
┃ Component                  ┃ Type       ┃   Avail % ┃ Downtime/yr ┃  $/Hour ┃ Loss/yr ┃ Risk                         ┃
│ deploy-faultray-demo-redis │ database   │  99.9884% │       1.01h │ $10,000 │ $10,138 │ Single point of failure (no  │
│                            │            │           │             │         │         │ replicas); 2 dependent       │
│                            │            │           │             │         │         │ component(s)                 │
```

At `COLUMNS=80` long ids wrap (taller, still readable) instead of being cut mid-digit.

## Regression tests (`tests/test_cli_financial_table.py`)

3 new tests:
1. `test_headers_render_in_full_at_wide_terminal` — at 120 cols, header labels not truncated.
2. `test_no_values_truncated_mid_digit_at_wide_terminal` — regex `\$[\d,]+…` finds zero matches.
3. `test_table_renders_cleanly_at_narrow_terminal` — 80-col render doesn't crash.

All 3 pass locally.

## Risk
Low. Display-only change. No numeric value, no JSON payload, no API modified.

---
🤖 Generated with Claude Code

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
