### PR TITLE
security(admin): add RBAC auth to 22 unprotected admin.py routes (#100)

### DIFF
--- a/src/faultray/api/auth.py
+++ b/src/faultray/api/auth.py
@@ -106,6 +106,10 @@ PUBLIC_PATHS = frozenset({
     "/simulation",
     "/graph",
     "/simulation/run",
+    # ADMIN-AUTH (#100): health / versioning / docs endpoints stay public
+    "/api/health",
+    "/api/versions",
+    "/api-docs",
 })
 
 # Paths allowed when no users are configured (setup mode)

--- a/src/faultray/api/routes/admin.py
+++ b/src/faultray/api/routes/admin.py
@@ -25,6 +25,19 @@ router = APIRouter()
 
 
 # ---------------------------------------------------------------------------
+# ADMIN-AUTH (#100) — shared auth dependencies
+#
+# view_dashboard : viewer+ (HTML pages + read-only JSON listings)
+# run_simulation : editor+ (POST/DELETE that install, schedule, chat, etc.)
+#
+# Routes left intentionally public (see auth.py PUBLIC_PATHS / _is_public):
+#   /api/health, /api/versions, /api-docs, /setup, /auth/*
+# ---------------------------------------------------------------------------
+_READ_ACCESS = Depends(_require_permission("view_dashboard"))
+_WRITE_ACCESS = Depends(_require_permission("run_simulation"))
+
+
+# ---------------------------------------------------------------------------
 # Health, Versioning & API docs
 # ---------------------------------------------------------------------------
 
@@ -53,7 +66,7 @@ async def api_docs_page(request: Request):
 
 
 @router.get("/settings", response_class=HTMLResponse)
-async def settings_page(request: Request):
+async def settings_page(request: Request, _user=_READ_ACCESS):
     return templates.TemplateResponse(request, "settings.html", {
         "has_data": True,
     })
@@ -285,7 +298,7 @@ async def oauth_callback(request: Request, code: str = "", state: str = "", prov
 # ---------------------------------------------------------------------------
 
 @router.get("/marketplace", response_class=HTMLResponse)
-async def marketplace_page(request: Request):
+async def marketplace_page(request: Request, _user=_READ_ACCESS):
     """Marketplace HTML page."""
     graph = get_graph()
     has_data = bool(graph and graph.components)
@@ -299,6 +312,7 @@ async def marketplace_page(request: Request):
 async def list_marketplace_packages(
     category: str | None = None,
     provider: str | None = None,
+    _user=_READ_ACCESS,
 ):
     """List all marketplace packages."""
     from faultray.marketplace import ScenarioMarketplace
@@ -309,7 +323,7 @@ async def list_marketplace_packages(
 
 
 @router.get("/api/marketplace/packages/{package_id}", response_class=JSONResponse)
-async def get_marketplace_package(package_id: str):
+async def get_marketplace_package(package_id: str, _user=_READ_ACCESS):
     """Get a specific marketplace package by ID."""
     from faultray.marketplace import ScenarioMarketplace
 
@@ -322,7 +336,7 @@ async def get_marketplace_package(package_id: str):
 
 
 @router.post("/api/marketplace/install/{package_id}", response_class=JSONResponse)
-async def install_marketplace_package(package_id: str):
+async def install_marketplace_package(package_id: str, _user=_WRITE_ACCESS):
     """Install a marketplace package."""
     from faultray.marketplace import ScenarioMarketplace
 
@@ -347,7 +361,7 @@ async def install_marketplace_package(package_id: str):
 
 
 @router.get("/api/marketplace/featured", response_class=JSONResponse)
-async def get_featured_packages():
+async def get_featured_packages(_user=_READ_ACCESS):
     """Get featured marketplace packages."""
     from faultray.marketplace import ScenarioMarketplace
 
@@ -357,7 +371,7 @@ async def get_featured_packages():
 
 
 @router.get("/api/marketplace/categories", response_class=JSONResponse)
-async def get_marketplace_categories():
+async def get_marketplace_categories(_user=_READ_ACCESS):
     """Get all marketplace categories."""
     from faultray.marketplace import ScenarioMarketplace
 
@@ -367,7 +381,7 @@ async def get_marketplace_categories():
 
 
 @router.get("/api/marketplace/popular", response_class=JSONResponse)
-async def get_popular_packages():
+async def get_popular_packages(_user=_READ_ACCESS):
     """Get most popular marketplace packages."""
     from faultray.marketplace import ScenarioMarketplace
 
@@ -377,7 +391,7 @@ async def get_popular_packages():
 
 
 @router.get("/api/marketplace/search", response_class=JSONResponse)
-async def search_marketplace_packages(q: str = ""):
+async def search_marketplace_packages(q: str = "", _user=_READ_ACCESS):
     """Search marketplace packages by query."""
     from faultray.marketplace import ScenarioMarketplace
 
@@ -391,7 +405,7 @@ async def search_marketplace_packages(q: str = ""):
 # ---------------------------------------------------------------------------
 
 @router.get("/calendar", response_class=HTMLResponse)
-async def calendar_page(request: Request):
+async def calendar_page(request: Request, _user=_READ_ACCESS):
     """Chaos Calendar page."""
     graph = get_graph()
     return templates.TemplateResponse(request, "calendar.html", {
@@ -401,7 +415,7 @@ async def calendar_page(request: Request):
 
 
 @router.get("/api/calendar", response_class=JSONResponse)
-async def api_calendar_view():
+async def api_calendar_view(_user=_READ_ACCESS):
     """Return calendar view JSON."""
     from faultray.scheduler.chaos_calendar import ChaosCalendar
 
@@ -421,7 +435,7 @@ async def api_calendar_view():
 
 
 @router.post("/api/calendar/schedule", response_class=JSONResponse)
-async def api_calendar_schedule(request: Request):
+async def api_calendar_schedule(request: Request, _user=_WRITE_ACCESS):
     """Schedule a new chaos experiment."""
     from faultray.scheduler.chaos_calendar import ChaosCalendar, ChaosExperiment
 
@@ -453,7 +467,7 @@ async def api_calendar_schedule(request: Request):
 
 
 @router.delete("/api/calendar/{experiment_id}", response_class=JSONResponse)
-async def api_calendar_cancel(experiment_id: str):
+async def api_calendar_cancel(experiment_id: str, _user=_WRITE_ACCESS):
     """Cancel a scheduled experiment."""
     from faultray.scheduler.chaos_calendar import ChaosCalendar
 
@@ -465,7 +479,7 @@ async def api_calendar_cancel(experiment_id: str):
 
 
 @router.post("/api/calendar/auto-schedule", response_class=JSONResponse)
-async def api_calendar_auto_schedule():
+async def api_calendar_auto_schedule(_user=_WRITE_ACCESS):
     """Auto-schedule experiments for critical components."""
     from faultray.scheduler.chaos_calendar import ChaosCalendar
 
@@ -482,7 +496,7 @@ async def api_calendar_auto_schedule():
 
 
 @router.get("/api/calendar/ical")
-async def api_calendar_ical():
+async def api_calendar_ical(_user=_READ_ACCESS):
     """Download iCalendar (.ics) file."""
     from faultray.scheduler.chaos_calendar import ChaosCalendar
 
@@ -500,7 +514,7 @@ async def api_calendar_ical():
 # ---------------------------------------------------------------------------
 
 @router.get("/chat", response_class=HTMLResponse)
-async def chat_page(request: Request):
+async def chat_page(request: Request, _user=_READ_ACCESS):
     """Chat interface page."""
     from faultray.api.chat_engine import ChatEngine
 
@@ -517,7 +531,7 @@ async def chat_page(request: Request):
 
 
 @router.post("/api/chat", response_class=JSONResponse)
-async def chat_api(request: Request):
+async def chat_api(request: Request, _user=_WRITE_ACCESS):
     """Process a chat message about infrastructure."""
     from faultray.api.chat_engine import ChatEngine
 
@@ -547,23 +561,75 @@ async def chat_api(request: Request):
 # Slack Bot
 # ---------------------------------------------------------------------------
 
+def _verify_slack_signature(request: Request, body: bytes) -> bool:
+    """Verify Slack request signature per https://api.slack.com/authentication/verifying-requests-from-slack.
+
+    Returns True if:
+    - SLACK_SIGNING_SECRET env var is set AND signature is valid AND timestamp is within 5 minutes
+    - SLACK_SIGNING_SECRET is NOT set (backward-compatible mode for self-hosted dev without Slack)
+      and FAULTRAY_ALLOW_UNSIGNED_SLACK=1 is explicitly set (escape hatch for local dev only)
+
+    Returns False otherwise (rejecting the request).
+    """
+    import hashlib
+    import hmac
+    import time as _time
+
+    signing_secret = os.environ.get("SLACK_SIGNING_SECRET", "")
+    if not signing_secret:
+        # Safety: without secret configured, only allow if operator explicitly
+        # opts into unsigned (dev-only). Default posture is "reject".
+        return os.environ.get("FAULTRAY_ALLOW_UNSIGNED_SLACK", "").lower() in ("1", "true", "yes")
+
+    ts = request.headers.get("x-slack-request-timestamp", "")
+    sig = request.headers.get("x-slack-signature", "")
+    if not ts or not sig:
+        return False
+
+    # Reject replay attacks (>5 min old)
+    try:
+        if abs(int(_time.time()) - int(ts)) > 60 * 5:
+            return False
+    except ValueError:
+        return False
+
+    basestring = b"v0:" + ts.encode() + b":" + body
+    expected = "v0=" + hmac.new(
+        signing_secret.encode(), basestring, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected, sig)
+
+
 @router.post("/api/slack/commands", response_class=JSONResponse)
 async def slack_command_handler(request: Request):
-    """Handle Slack slash commands."""
+    """Handle Slack slash commands.
+
+    Public endpoint (Slack has no Bearer token) but authenticated via
+    Slack signing-secret HMAC verification (ADMIN-AUTH #100).
+    """
+    raw_body = await request.body()
+    if not _verify_slack_signature(request, raw_body):
+        logger.warning("Slack command rejected: invalid or missing signature")
+        return JSONResponse(
+            {"error": "Invalid Slack signature"}, status_code=401
+        )
     try:
+        # Parse form from raw body bytes (body already read for signature verify).
+        from urllib.parse import parse_qs
         try:
-            form = await request.form()
-            text = form.get("text", "help")
-            user_id = form.get("user_id", "")
-            channel_id = form.get("channel_id", "")
+            parsed = parse_qs(raw_body.decode(errors="replace"))
+            text = (parsed.get("text", ["help"]) or ["help"])[0]
+            user_id = (parsed.get("user_id", [""]) or [""])[0]
+            channel_id = (parsed.get("channel_id", [""]) or [""])[0]
         except Exception:
+            import json as _json
             try:
-                body = await request.json()
+                jbody = _json.loads(raw_body.decode(errors="replace") or "{}")
             except Exception:
-                body = {}
-            text = body.get("text", "help")
-            user_id = body.get("user_id", "")
-            channel_id = body.get("channel_id", "")
+                jbody = {}
+            text = jbody.get("text", "help")
+            user_id = jbody.get("user_id", "")
+            channel_id = jbody.get("channel_id", "")
 
         from faultray.integrations.slack_bot import FaultRaySlackBot, parse_slack_command
 
@@ -587,7 +653,7 @@ async def slack_command_handler(request: Request):
 # ---------------------------------------------------------------------------
 
 @router.get("/templates", response_class=HTMLResponse)
-async def templates_page(request: Request, category: str | None = None):
+async def templates_page(request: Request, category: str | None = None, _user=_READ_ACCESS):
     """Render the Template Gallery page."""
     from dataclasses import asdict
 
@@ -610,7 +676,7 @@ async def templates_page(request: Request, category: str | None = None):
 
 
 @router.get("/api/templates", response_class=JSONResponse)
-async def api_list_templates(category: str | None = None):
+async def api_list_templates(category: str | None = None, _user=_READ_ACCESS):
     """List all gallery templates as JSON."""
     from dataclasses import asdict
 
@@ -622,7 +688,7 @@ async def api_list_templates(category: str | None = None):
 
 
 @router.get("/api/templates/{template_id}", response_class=JSONResponse)
-async def api_get_template(template_id: str):
+async def api_get_template(template_id: str, _user=_READ_ACCESS):
     """Get a specific template by ID."""
     from dataclasses import asdict
 
@@ -641,7 +707,7 @@ async def api_get_template(template_id: str):
 # ---------------------------------------------------------------------------
 
 @router.get("/agents", response_class=HTMLResponse)
-async def agents_page(request: Request):
+async def agents_page(request: Request, _user=_READ_ACCESS):
     """AI Agent assessment page."""
     graph = get_graph()
     has_data = len(graph.components) > 0
@@ -735,7 +801,7 @@ async def agent_scenarios(request: Request, user=Depends(_require_permission("vi
 # ---------------------------------------------------------------------------
 
 @router.get("/supply-chain", response_class=HTMLResponse)
-async def supply_chain_page(request: Request):
+async def supply_chain_page(request: Request, _user=_READ_ACCESS):
     """Supply chain attack analysis page."""
     graph = get_graph()
     has_data = len(graph.components) > 0

--- a/src/faultray/api/routes/admin.py
+++ b/src/faultray/api/routes/admin.py
@@ -566,8 +566,8 @@ def _verify_slack_signature(request: Request, body: bytes) -> bool:
 
     Returns True if:
     - SLACK_SIGNING_SECRET env var is set AND signature is valid AND timestamp is within 5 minutes
-    - SLACK_SIGNING_SECRET is NOT set (backward-compatible mode for self-hosted dev without Slack)
-      and FAULTRAY_ALLOW_UNSIGNED_SLACK=1 is explicitly set (escape hatch for local dev only)
+    - SLACK_SIGNING_SECRET is NOT set AND FAULTRAY_ALLOW_UNSIGNED_SLACK=1
+      AND FAULTRAY_ENV != production (dev-only escape hatch)
 
     Returns False otherwise (rejecting the request).
     """
@@ -577,9 +577,19 @@ def _verify_slack_signature(request: Request, body: bytes) -> bool:
 
     signing_secret = os.environ.get("SLACK_SIGNING_SECRET", "")
     if not signing_secret:
-        # Safety: without secret configured, only allow if operator explicitly
-        # opts into unsigned (dev-only). Default posture is "reject".
-        return os.environ.get("FAULTRAY_ALLOW_UNSIGNED_SLACK", "").lower() in ("1", "true", "yes")
+        # Dev escape hatch — explicitly disabled when FAULTRAY_ENV indicates
+        # production. This closes the self-review finding that a stray
+        # FAULTRAY_ALLOW_UNSIGNED_SLACK=1 in prod would silently open the
+        # endpoint to unauthenticated callers (#100 post-review).
+        env = os.environ.get("FAULTRAY_ENV", "").lower()
+        if env in ("production", "prod", "live"):
+            logger.warning(
+                "Slack: SLACK_SIGNING_SECRET missing in production — rejecting"
+            )
+            return False
+        return os.environ.get("FAULTRAY_ALLOW_UNSIGNED_SLACK", "").lower() in (
+            "1", "true", "yes"
+        )
 
     ts = request.headers.get("x-slack-request-timestamp", "")
     sig = request.headers.get("x-slack-signature", "")

--- a/tests/test_admin_auth.py
+++ b/tests/test_admin_auth.py
@@ -1,0 +1,290 @@
+"""Auth/authorization tests for admin.py routes (#100).
+
+Verifies the wiring added by security/admin-require-permission:
+- Public endpoints (health, versions, api-docs, setup, auth/*) stay open
+- Protected HTML pages + read-only APIs require view_dashboard (viewer+)
+- Write endpoints (marketplace install, calendar CRUD, chat) require
+  run_simulation (editor+); viewer gets 403
+- Slack webhook uses Slack signature HMAC instead of bearer auth
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+from faultray.api.auth import hash_api_key
+from faultray.api.database import Base, UserRow, _get_engine, get_session_factory
+from faultray.api.server import _rate_limiter, app
+from tests.conftest import TEST_API_KEY, _run_async
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_VIEWER_KEY = "test-viewer-key-for-#100"
+_VIEWER_HASH = hash_api_key(_VIEWER_KEY)
+
+
+async def _ensure_user(email: str, key_hash: str, role: str) -> None:
+    engine = _get_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sf = get_session_factory()
+    async with sf() as session:
+        from sqlalchemy import select
+
+        result = await session.execute(
+            select(UserRow).where(UserRow.api_key_hash == key_hash)
+        )
+        if result.scalar_one_or_none() is None:
+            session.add(
+                UserRow(email=email, name=email, api_key_hash=key_hash, role=role)
+            )
+            await session.commit()
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    """Ensure admin test user + viewer exist; reset rate limiter each test."""
+    from tests.conftest import _setup_test_user
+
+    _setup_test_user()
+    _run_async(_ensure_user("viewer@test.local", _VIEWER_HASH, "viewer"))
+    _rate_limiter.requests.clear()
+    yield
+    _rate_limiter.requests.clear()
+
+
+@pytest.fixture
+def anon_client():
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def admin_client():
+    c = TestClient(app, raise_server_exceptions=False)
+    c.headers["Authorization"] = f"Bearer {TEST_API_KEY}"
+    return c
+
+
+@pytest.fixture
+def viewer_client():
+    c = TestClient(app, raise_server_exceptions=False)
+    c.headers["Authorization"] = f"Bearer {_VIEWER_KEY}"
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Public endpoints stay open
+# ---------------------------------------------------------------------------
+
+
+class TestPublicEndpoints:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/api/health",
+            "/api/versions",
+            "/api-docs",
+        ],
+    )
+    def test_public_paths_no_auth(self, anon_client, path):
+        resp = anon_client.get(path)
+        # 200 expected for all three (api-docs returns HTML; health/versions return JSON)
+        assert resp.status_code == 200, f"{path} returned {resp.status_code}"
+
+
+# ---------------------------------------------------------------------------
+# Protected read endpoints require view_dashboard
+# ---------------------------------------------------------------------------
+
+
+class TestReadProtection:
+    READ_PATHS = [
+        "/settings",
+        "/marketplace",
+        "/api/marketplace/packages",
+        "/api/marketplace/featured",
+        "/api/marketplace/categories",
+        "/api/marketplace/popular",
+        "/api/marketplace/search",
+        "/calendar",
+        "/api/calendar",
+        "/api/calendar/ical",
+        "/chat",
+        "/templates",
+        "/api/templates",
+        "/agents",
+        "/supply-chain",
+    ]
+
+    @pytest.mark.parametrize("path", READ_PATHS)
+    def test_anon_gets_401_or_403(self, anon_client, path):
+        resp = anon_client.get(path)
+        assert resp.status_code in (401, 403), (
+            f"{path}: expected 401/403 without auth, got {resp.status_code}"
+        )
+
+    @pytest.mark.parametrize("path", READ_PATHS)
+    def test_viewer_allowed(self, viewer_client, path):
+        resp = viewer_client.get(path)
+        # 200 / 404 are fine — 401/403 are not
+        assert resp.status_code not in (401, 403), (
+            f"{path}: viewer should have view_dashboard, got {resp.status_code}"
+        )
+
+    @pytest.mark.parametrize("path", READ_PATHS)
+    def test_admin_allowed(self, admin_client, path):
+        resp = admin_client.get(path)
+        assert resp.status_code not in (401, 403), (
+            f"{path}: admin should always work, got {resp.status_code}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Write endpoints require run_simulation (editor+)
+# ---------------------------------------------------------------------------
+
+
+class TestWriteProtection:
+    @pytest.mark.parametrize(
+        "method,path,body",
+        [
+            ("POST", "/api/marketplace/install/nonexistent-pkg", None),
+            ("POST", "/api/calendar/schedule", {"name": "x", "scenario_ids": []}),
+            ("DELETE", "/api/calendar/nonexistent-exp", None),
+            ("POST", "/api/calendar/auto-schedule", None),
+            ("POST", "/api/chat", {"question": "hello"}),
+        ],
+    )
+    def test_anon_rejected(self, anon_client, method, path, body):
+        resp = anon_client.request(method, path, json=body)
+        assert resp.status_code in (401, 403), (
+            f"{method} {path}: expected 401/403 anon, got {resp.status_code}"
+        )
+
+    @pytest.mark.parametrize(
+        "method,path,body",
+        [
+            ("POST", "/api/marketplace/install/nonexistent-pkg", None),
+            ("POST", "/api/calendar/schedule", {"name": "x", "scenario_ids": []}),
+            ("DELETE", "/api/calendar/nonexistent-exp", None),
+            ("POST", "/api/calendar/auto-schedule", None),
+            ("POST", "/api/chat", {"question": "hello"}),
+        ],
+    )
+    def test_viewer_forbidden(self, viewer_client, method, path, body):
+        resp = viewer_client.request(method, path, json=body)
+        # Viewer has view_dashboard but NOT run_simulation → 403
+        assert resp.status_code == 403, (
+            f"{method} {path}: expected 403 for viewer, got {resp.status_code}"
+        )
+
+    @pytest.mark.parametrize(
+        "method,path,body",
+        [
+            ("POST", "/api/marketplace/install/nonexistent-pkg", None),
+            ("DELETE", "/api/calendar/nonexistent-exp", None),
+            ("POST", "/api/chat", {"question": "hello"}),
+        ],
+    )
+    def test_admin_passes_auth(self, admin_client, method, path, body):
+        resp = admin_client.request(method, path, json=body)
+        # Auth passes; status depends on route logic (404, 400, 200 are all fine)
+        assert resp.status_code not in (401, 403), (
+            f"{method} {path}: admin rejected with {resp.status_code}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Slack webhook signature verification
+# ---------------------------------------------------------------------------
+
+
+class TestSlackSignature:
+    _SECRET = "test-slack-signing-secret-#100"  # pragma: allowlist secret
+
+    def _sign(self, body: str, ts: str) -> str:
+        basestring = f"v0:{ts}:{body}".encode()
+        return "v0=" + hmac.new(
+            self._SECRET.encode(), basestring, hashlib.sha256
+        ).hexdigest()
+
+    def test_rejects_without_signing_secret_by_default(self, anon_client):
+        # SLACK_SIGNING_SECRET not set, FAULTRAY_ALLOW_UNSIGNED_SLACK not set → reject
+        os.environ.pop("SLACK_SIGNING_SECRET", None)
+        os.environ.pop("FAULTRAY_ALLOW_UNSIGNED_SLACK", None)
+        resp = anon_client.post("/api/slack/commands", data="text=help")
+        assert resp.status_code == 401
+
+    def test_rejects_invalid_signature(self, anon_client):
+        os.environ["SLACK_SIGNING_SECRET"] = self._SECRET
+        try:
+            ts = str(int(time.time()))
+            resp = anon_client.post(
+                "/api/slack/commands",
+                data="text=help",
+                headers={
+                    "x-slack-request-timestamp": ts,
+                    "x-slack-signature": "v0=deadbeef",
+                },
+            )
+            assert resp.status_code == 401
+        finally:
+            os.environ.pop("SLACK_SIGNING_SECRET", None)
+
+    def test_rejects_stale_timestamp(self, anon_client):
+        os.environ["SLACK_SIGNING_SECRET"] = self._SECRET
+        try:
+            ts = str(int(time.time()) - 60 * 10)  # 10 min old
+            body = "text=help"
+            resp = anon_client.post(
+                "/api/slack/commands",
+                data=body,
+                headers={
+                    "x-slack-request-timestamp": ts,
+                    "x-slack-signature": self._sign(body, ts),
+                },
+            )
+            assert resp.status_code == 401
+        finally:
+            os.environ.pop("SLACK_SIGNING_SECRET", None)
+
+    def test_accepts_valid_signature(self, anon_client):
+        os.environ["SLACK_SIGNING_SECRET"] = self._SECRET
+        try:
+            ts = str(int(time.time()))
+            body = "text=help&user_id=U123&channel_id=C123"
+            resp = anon_client.post(
+                "/api/slack/commands",
+                data=body,
+                headers={
+                    "x-slack-request-timestamp": ts,
+                    "x-slack-signature": self._sign(body, ts),
+                    "content-type": "application/x-www-form-urlencoded",
+                },
+            )
+            # Signature valid — downstream may 200 or 500 depending on slack bot
+            # deps, but must not be 401 (signature fail).
+            assert resp.status_code != 401, (
+                f"Valid signature rejected with {resp.status_code}"
+            )
+        finally:
+            os.environ.pop("SLACK_SIGNING_SECRET", None)
+
+    def test_unsigned_allowed_with_explicit_opt_in(self, anon_client):
+        os.environ.pop("SLACK_SIGNING_SECRET", None)
+        os.environ["FAULTRAY_ALLOW_UNSIGNED_SLACK"] = "1"
+        try:
+            resp = anon_client.post("/api/slack/commands", data="text=help")
+            # Not rejected by signature check (may still 200/500 from bot logic)
+            assert resp.status_code != 401
+        finally:
+            os.environ.pop("FAULTRAY_ALLOW_UNSIGNED_SLACK", None)

--- a/tests/test_admin_auth.py
+++ b/tests/test_admin_auth.py
@@ -281,6 +281,7 @@ class TestSlackSignature:
 
     def test_unsigned_allowed_with_explicit_opt_in(self, anon_client):
         os.environ.pop("SLACK_SIGNING_SECRET", None)
+        os.environ.pop("FAULTRAY_ENV", None)
         os.environ["FAULTRAY_ALLOW_UNSIGNED_SLACK"] = "1"
         try:
             resp = anon_client.post("/api/slack/commands", data="text=help")
@@ -288,3 +289,17 @@ class TestSlackSignature:
             assert resp.status_code != 401
         finally:
             os.environ.pop("FAULTRAY_ALLOW_UNSIGNED_SLACK", None)
+
+    def test_escape_hatch_disabled_in_production(self, anon_client):
+        """FAULTRAY_ALLOW_UNSIGNED_SLACK must not bypass signature in prod."""
+        os.environ.pop("SLACK_SIGNING_SECRET", None)
+        os.environ["FAULTRAY_ALLOW_UNSIGNED_SLACK"] = "1"
+        os.environ["FAULTRAY_ENV"] = "production"
+        try:
+            resp = anon_client.post("/api/slack/commands", data="text=help")
+            assert resp.status_code == 401, (
+                "escape hatch must NOT work when FAULTRAY_ENV=production"
+            )
+        finally:
+            os.environ.pop("FAULTRAY_ALLOW_UNSIGNED_SLACK", None)
+            os.environ.pop("FAULTRAY_ENV", None)

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -1249,18 +1249,42 @@ class TestEdgeCases:
 
 
 class TestSlackEndpoint:
-    """POST /api/slack/commands."""
+    """POST /api/slack/commands — signature-verified webhook (#100)."""
+
+    def _sign_and_post(self, client, body: str):
+        import hashlib
+        import hmac
+        import os
+        import time as _time
+
+        secret = "test-slack-signing-secret"  # pragma: allowlist secret
+        os.environ["SLACK_SIGNING_SECRET"] = secret
+        ts = str(int(_time.time()))
+        sig = "v0=" + hmac.new(
+            secret.encode(), f"v0:{ts}:{body}".encode(), hashlib.sha256
+        ).hexdigest()
+        try:
+            return client.post(
+                "/api/slack/commands",
+                content=body,
+                headers={
+                    "x-slack-request-timestamp": ts,
+                    "x-slack-signature": sig,
+                    "content-type": "application/x-www-form-urlencoded",
+                },
+            )
+        finally:
+            os.environ.pop("SLACK_SIGNING_SECRET", None)
 
     def test_slack_help_command(self, client):
-        resp = client.post(
-            "/api/slack/commands",
-            json={"text": "help", "user_id": "U123", "channel_id": "C456"},
+        resp = self._sign_and_post(
+            client, "text=help&user_id=U123&channel_id=C456"
         )
-        # May succeed or fail depending on _model_path; should not crash
+        # Signature accepted; downstream may succeed or fail on _model_path
         assert resp.status_code in (200, 500)
 
     def test_slack_empty_command(self, client):
-        resp = client.post("/api/slack/commands", json={})
+        resp = self._sign_and_post(client, "")
         assert resp.status_code in (200, 500)
 
 

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -183,10 +183,41 @@ class TestGraphQLApi:
 # ===================================================================
 
 class TestSlackCommands:
+    """POST /api/slack/commands — signature-verified webhook (#100).
+
+    Slack endpoint no longer uses Bearer auth; it verifies X-Slack-Signature
+    HMAC with SLACK_SIGNING_SECRET. Tests sign each request explicitly.
+    """
+
+    @staticmethod
+    async def _signed_post(client, body: str):
+        import hashlib
+        import hmac
+        import os
+        import time as _time
+
+        secret = "test-slack-signing-secret"  # pragma: allowlist secret
+        os.environ["SLACK_SIGNING_SECRET"] = secret
+        ts = str(int(_time.time()))
+        sig = "v0=" + hmac.new(
+            secret.encode(), f"v0:{ts}:{body}".encode(), hashlib.sha256
+        ).hexdigest()
+        try:
+            return await client.post(
+                "/api/slack/commands",
+                content=body,
+                headers={
+                    "x-slack-request-timestamp": ts,
+                    "x-slack-signature": sig,
+                    "content-type": "application/x-www-form-urlencoded",
+                },
+            )
+        finally:
+            os.environ.pop("SLACK_SIGNING_SECRET", None)
+
     async def test_slack_help_command(self, client):
-        resp = await client.post(
-            "/api/slack/commands",
-            json={"text": "help", "user_id": "U123", "channel_id": "C456"},
+        resp = await self._signed_post(
+            client, "text=help&user_id=U123&channel_id=C456"
         )
         assert resp.status_code in (200, 500)
         if resp.status_code == 200:
@@ -194,23 +225,20 @@ class TestSlackCommands:
             assert "text" in data or "blocks" in data
 
     async def test_slack_score_command(self, client):
-        resp = await client.post(
-            "/api/slack/commands",
-            json={"text": "score", "user_id": "U123", "channel_id": "C456"},
+        resp = await self._signed_post(
+            client, "text=score&user_id=U123&channel_id=C456"
         )
         assert resp.status_code in (200, 500)
 
     async def test_slack_simulate_command(self, client):
-        resp = await client.post(
-            "/api/slack/commands",
-            json={"text": "simulate", "user_id": "U123", "channel_id": "C456"},
+        resp = await self._signed_post(
+            client, "text=simulate&user_id=U123&channel_id=C456"
         )
         assert resp.status_code in (200, 500)
 
     async def test_slack_empty_text(self, client):
-        resp = await client.post(
-            "/api/slack/commands",
-            json={"text": "", "user_id": "U123", "channel_id": "C456"},
+        resp = await self._signed_post(
+            client, "text=&user_id=U123&channel_id=C456"
         )
         assert resp.status_code in (200, 500)
 


### PR DESCRIPTION
## Summary
admin.py 全 34 route のうち 4 route にしか \`_require_permission\` がかかっておらず、残り 30 route が**認証なしで呼べる P1 security 欠陥**を修正。

- HTML ページ + 読取 API 17 route に **view_dashboard** (viewer+)
- 書込 API 5 route に **run_simulation** (editor+)
- \`/api/slack/commands\` に **Slack signing-secret HMAC** 検証 (replay 防止 5 min)
- 公開のまま維持: \`/api/health\` \`/api/versions\` \`/api-docs\` \`/setup\` \`/auth/*\` (`PUBLIC_PATHS` に追加)
- Closes #100

## 監査表 (34 route の認可状態)

| カテゴリ | route 数 | 認可 |
|---|---|---|
| PUBLIC (health, versions, docs, setup, OAuth) | 7 | — (signed off) |
| READ (HTML + JSON lists) | 17 | \`view_dashboard\` |
| WRITE (install/schedule/delete/chat) | 5 | \`run_simulation\` |
| Slack webhook | 1 | HMAC signature verify |
| 既存 \`_require_permission\` (agent*/supply-chain analyze) | 4 | \`view_results\` (既存) |

## Slack signing-secret 実装
\`\`\`
X-Slack-Request-Timestamp + X-Slack-Signature (v0=HMAC_SHA256)
\`\`\`
- \`SLACK_SIGNING_SECRET\` 設定時: 標準の Slack 検証
- 未設定 + \`FAULTRAY_ALLOW_UNSIGNED_SLACK=1\`: 開発用 opt-in 許可
- それ以外: 401 で拒否
- timestamp > 5 min の replay は拒否

## Test 結果 (ローカル)
- \`test_admin_auth.py\`: **66/66 pass** (新規)
- 既存 \`test_api_integration.py\` admin 21 件: **regression なし**
- 広域 \`test_api_integration + test_api_server + test_api_extended + test_admin_auth\`: **315/315 pass**

## Test plan (CI)
- [ ] Python test suite で 66 + 既存 all green
- [ ] mypy strict model/: error 0
- [ ] ruff: lint 0
- [ ] E2E flow: admin token 付きで全 route 通過確認

## 破壊的変更
- 無認証で curl していた運用があった場合は 401 になる。**これは意図した修正**。
- Slack 連携本番利用者は \`SLACK_SIGNING_SECRET\` の設定が必須に。未設定時は \`FAULTRAY_ALLOW_UNSIGNED_SLACK=1\` で従来挙動に opt-in 可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray/pull/109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced role-based access control for admin dashboard features, distinguishing between viewer (read-only) and editor (write) permissions across settings, marketplace, calendar, chat, templates, and agent sections.
  * Added Slack webhook signature verification for slash commands to enhance security.

* **Security**
  * Made health check, version, and API documentation endpoints publicly accessible without authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->