### PR TITLE
ci(release): add SBOM + sigstore cosign + SLSA provenance (#95)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Extract version from tag or release
         id: get_version
         run: |
+          set -euo pipefail
           if [ "${{ github.event_name }}" = "push" ]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
           else
@@ -39,38 +40,137 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Extracted version: ${VERSION}"
 
+  # ----------------------------------------------------------------------
+  # PyPI publish + SBOM + SLSA provenance attestation (#95)
+  # ----------------------------------------------------------------------
   publish-pypi:
     needs: [test, extract-version]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
-      id-token: write
+      id-token: write         # OIDC for Trusted Publisher + sigstore
+      contents: write         # attach artifacts to GitHub Release
+      attestations: write     # actions/attest-build-provenance
     steps:
       - uses: actions/checkout@v6
+
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - run: pip install build
-      - run: python -m build
-      - uses: pypa/gh-action-pypi-publish@release/v1
 
+      - name: Build wheel + sdist
+        run: |
+          set -euo pipefail
+          pip install build
+          python -m build
+          ls -la dist/
+
+      - name: Generate CycloneDX SBOM for Python package
+        # anchore/sbom-action wraps syft. Produces both SPDX and CycloneDX
+        # output formats on the dist/ directory.
+        uses: anchore/sbom-action@v0
+        with:
+          path: dist/
+          format: cyclonedx-json
+          artifact-name: faultray-${{ needs.extract-version.outputs.version }}-python.cdx.json
+          output-file: dist/faultray-${{ needs.extract-version.outputs.version }}-python.cdx.json
+
+      - name: Attest build provenance (SLSA v1)
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "dist/*.whl,dist/*.tar.gz"
+
+      - name: Publish to PyPI via Trusted Publisher (OIDC)
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Attach wheel + sdist + SBOM to GitHub Release
+        # Only runs when a Release event fires (not for raw tag push), so
+        # the softprops action receives the existing release to upload to.
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
+            dist/*.cdx.json
+
+  # ----------------------------------------------------------------------
+  # Docker publish + cosign sign + SBOM (#95)
+  # ----------------------------------------------------------------------
   publish-docker:
     needs: [test, extract-version]
     runs-on: ubuntu-latest
     permissions:
-      packages: write
-      contents: read
+      packages: write         # push to ghcr.io
+      contents: write         # attach SBOM to release
+      id-token: write         # cosign OIDC keyless signing
+      attestations: write     # SLSA provenance
+    env:
+      IMAGE: ghcr.io/${{ github.repository }}
+      TAG: v${{ needs.extract-version.outputs.version }}
     steps:
       - uses: actions/checkout@v6
+
       - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v7
+
+      - name: Install cosign (sigstore)
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: "v2.4.1"
+
+      - name: Build & push Docker image
+        id: build
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:v${{ needs.extract-version.outputs.version }}
-            ghcr.io/${{ github.repository }}:latest
+            ${{ env.IMAGE }}:${{ env.TAG }}
+            ${{ env.IMAGE }}:latest
+
+      - name: Sign container image (sigstore keyless)
+        run: |
+          set -euo pipefail
+          # Sign by digest to pin the exact image bytes
+          cosign sign --yes "${IMAGE}@${DIGEST}"
+        env:
+          IMAGE: ${{ env.IMAGE }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+
+      - name: Generate CycloneDX SBOM for Docker image
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.IMAGE }}:${{ env.TAG }}
+          format: cyclonedx-json
+          artifact-name: faultray-${{ needs.extract-version.outputs.version }}-docker.cdx.json
+          output-file: faultray-${{ needs.extract-version.outputs.version }}-docker.cdx.json
+
+      - name: Attach SBOM to Docker image (cosign attest)
+        run: |
+          set -euo pipefail
+          cosign attest --yes \
+            --predicate "faultray-${VERSION}-docker.cdx.json" \
+            --type cyclonedx \
+            "${IMAGE}@${DIGEST}"
+        env:
+          IMAGE: ${{ env.IMAGE }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+          VERSION: ${{ needs.extract-version.outputs.version }}
+
+      - name: Attest Docker build provenance (SLSA v1)
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Attach Docker SBOM to GitHub Release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            faultray-${{ needs.extract-version.outputs.version }}-docker.cdx.json

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,6 +36,17 @@ When using FaultRay in production:
 - Keep FaultRay updated to the latest version
 - Review the [DORA compliance docs](docs/enterprise/compliance.md)
 
+## Supply-chain integrity (#95)
+
+Every published release ships three cryptographic signals:
+
+1. **CycloneDX SBOM** — `.cdx.json` for Python dist + Docker image
+2. **SLSA v1 build provenance** — attested via `actions/attest-build-provenance`
+3. **Sigstore cosign signature** — keyless OIDC signing for Docker images
+
+See [`docs/release-verification.md`](docs/release-verification.md) for
+step-by-step verification commands (`gh attestation verify`, `cosign verify`).
+
 ---
 
 # セキュリティポリシー（日本語）

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -1,0 +1,101 @@
+# Release artifact verification
+
+FaultRay release pipeline (see `.github/workflows/release.yml`, #95) ships
+three integrity signals for every published version:
+
+1. **CycloneDX SBOM** — software bill of materials for Python wheel / sdist
+   and Docker image
+2. **SLSA v1 build provenance** — cryptographic attestation of *how* and
+   *where* the artifact was built
+3. **Sigstore cosign signature** — keyless OIDC signature on the Docker
+   image itself
+
+This page shows how downstream consumers can verify all three.
+
+## Prerequisites
+
+```bash
+# cosign (sigstore client)
+go install github.com/sigstore/cosign/v2/cmd/cosign@latest
+# OR via binary releases: https://github.com/sigstore/cosign/releases
+
+# GitHub CLI (for attestation verify)
+# https://cli.github.com
+```
+
+## 1. Verify SLSA provenance for Python wheel
+
+```bash
+gh attestation verify faultray-<VERSION>-py3-none-any.whl \
+  --owner mattyopon
+```
+
+Expected output includes:
+
+```
+✓ Verification succeeded!
+...
+Build: https://github.com/mattyopon/faultray/.github/workflows/release.yml
+```
+
+## 2. Verify Docker image signature (cosign keyless)
+
+```bash
+IMAGE=ghcr.io/mattyopon/faultray
+TAG=v<VERSION>
+
+cosign verify "${IMAGE}:${TAG}" \
+  --certificate-identity-regexp="^https://github.com/mattyopon/faultray" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
+```
+
+Verifies that the image was signed by a workflow run from the
+`mattyopon/faultray` repository using OIDC (no long-lived keys).
+
+## 3. Fetch + validate SBOM
+
+### Python package SBOM
+
+Download `faultray-<VERSION>-python.cdx.json` from the GitHub Release
+attachments, or regenerate locally:
+
+```bash
+syft packages dir:. -o cyclonedx-json > local-sbom.json
+```
+
+Feed into `grype`, `trivy`, or any SCA tool for vulnerability tracking.
+
+### Docker image SBOM
+
+SBOM is attached to the image itself via `cosign attest`:
+
+```bash
+cosign verify-attestation "${IMAGE}:${TAG}" \
+  --type cyclonedx \
+  --certificate-identity-regexp="^https://github.com/mattyopon/faultray" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  | jq -r '.payload' | base64 -d | jq '.predicate'
+```
+
+Or, for human consumption, download
+`faultray-<VERSION>-docker.cdx.json` from the GitHub Release assets.
+
+## 4. Verify SLSA provenance for Docker image
+
+The provenance is pushed to the registry alongside the image via
+`actions/attest-build-provenance@v2 --push-to-registry`.
+
+```bash
+gh attestation verify oci://${IMAGE}:${TAG} --owner mattyopon
+```
+
+## Supply-chain posture summary
+
+| Signal | Tooling | Scope |
+|---|---|---|
+| SBOM | anchore/sbom-action (syft) | Python dist/ + Docker image |
+| Provenance | actions/attest-build-provenance@v2 | SLSA v1, in-toto |
+| Image signature | sigstore cosign keyless (OIDC) | Docker only |
+| PyPI publish | Trusted Publisher (OIDC) | no long-lived tokens |
+
+For questions or security reports, see [SECURITY.md](../SECURITY.md).


### PR DESCRIPTION
## Summary
\`release.yml\` は PyPI / GHCR publish のみで、**supply chain 整合性の cryptographic signal が皆無**だった (Dependabot / Renovate の利用者が downstream で compromised artifact を検知不可能)。本 PR で以下を追加:

| Signal | Tooling | 対象 |
|---|---|---|
| **CycloneDX SBOM** | anchore/sbom-action (syft) | Python dist + Docker image |
| **SLSA v1 provenance** | actions/attest-build-provenance@v2 | wheel / sdist / image |
| **Image signature (keyless OIDC)** | sigstore cosign v2.4.1 | Docker image |
| **SBOM attestation** | cosign attest --type cyclonedx | Docker image |

Closes #95.

## 変更ファイル

### \`.github/workflows/release.yml\`
- \`publish-pypi\` job に:
  - SBOM 生成ステップ (\`dist/faultray-<VER>-python.cdx.json\`)
  - \`actions/attest-build-provenance@v2\` で wheel + sdist の SLSA attestation
  - release event 時に wheel / sdist / SBOM を GitHub Releases に attach
- \`publish-docker\` job に:
  - \`sigstore/cosign-installer@v3\` を追加
  - \`cosign sign --yes\` で digest 指定 keyless 署名
  - image SBOM 生成 + \`cosign attest --type cyclonedx\`
  - \`--push-to-registry\` で provenance を OCI registry に push
- permissions 追加: \`id-token: write\`, \`attestations: write\`, \`contents: write\`

### \`docs/release-verification.md\` (新規)
\`gh attestation verify\` / \`cosign verify\` / \`cosign verify-attestation\` の runbook。Python wheel / Docker image / SBOM それぞれの検証手順 verbatim。

### \`SECURITY.md\`
\"Supply-chain integrity (#95)\" セクション追加、上記 runbook への link。

## Test plan (CI)
- [ ] 本 PR の push では \`release.yml\` は triggerされない (tags / release 専用)
- [ ] 既存 \`ci.yml\` に regression なし
- [ ] yaml syntax: \`python -c "import yaml; yaml.safe_load(...)"\` で OK (ローカル確認済)

## 検証プラン (次回リリース時)
1. \`git tag v11.3.0 && git push --tags\` で workflow を発火
2. \`gh attestation verify faultray-11.3.0-py3-none-any.whl --owner mattyopon\` が pass
3. \`cosign verify ghcr.io/mattyopon/faultray:v11.3.0 --certificate-identity-regexp="^https://github.com/mattyopon/faultray" --certificate-oidc-issuer="https://token.actions.githubusercontent.com"\` が pass
4. \`cosign verify-attestation ... --type cyclonedx\` で SBOM が参照可能

## Rollback
- 本 PR を revert するだけで元の release.yml に戻る
- 既に publish 済みの artifact は影響なし (attestation は additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cryptographic integrity verification for release artifacts to ensure supply-chain security

* **Documentation**
  * New release verification guide with instructions for validating artifact authenticity
  * Updated security documentation describing available cryptographic attestations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->