### PR TITLE
fix(schema,api): sync schema_version + OpenAPI version drift (#82, #101)

### DIFF
--- a/src/faultray/api/openapi_config.py
+++ b/src/faultray/api/openapi_config.py
@@ -4,6 +4,8 @@
 """OpenAPI configuration for FaultRay API."""
 from __future__ import annotations
 
+from faultray import __version__
+
 
 OPENAPI_TAGS = [
     {
@@ -56,7 +58,9 @@ OPENAPI_CONFIG = {
         "## Rate Limiting\n"
         "60 requests per minute per API key."
     ),
-    "version": "10.3.0",
+    # VERSION-SYNC (#101): source of truth is faultray.__version__ (kept in
+    # sync with pyproject.toml). Avoids drift between OpenAPI spec and release.
+    "version": __version__,
     "contact": {
         "name": "FaultRay Support",
         "url": "https://faultray.com",

--- a/src/faultray/cli/init_cmd.py
+++ b/src/faultray/cli/init_cmd.py
@@ -15,6 +15,7 @@ from rich.prompt import Confirm, IntPrompt, Prompt
 from rich.table import Table
 
 from faultray.cli.main import app, console
+from faultray.model.components import SCHEMA_VERSION
 
 # ---------------------------------------------------------------------------
 # Component presets for the wizard
@@ -376,8 +377,10 @@ def init(
 
     dependencies = _build_dependencies(all_components)
 
+    # SCHEMA-SYNC (#82): reference SCHEMA_VERSION from model.components
+    # to prevent drift between generated YAML and loader expectations.
     yaml_data: dict = {
-        "schema_version": "3.0",
+        "schema_version": SCHEMA_VERSION,
         "components": all_components,
         "dependencies": dependencies,
     }

--- a/src/faultray/templates/gallery.py
+++ b/src/faultray/templates/gallery.py
@@ -39,6 +39,7 @@ from faultray.model.components import (
     FailoverConfig,
     ResourceMetrics,
     RetryStrategy,
+    SCHEMA_VERSION,
     SecurityProfile,
 )
 from faultray.model.graph import InfraGraph
@@ -2046,8 +2047,10 @@ def _template_to_yaml_dict(template: InfraTemplate) -> dict:
                 dep[key] = edge[key]
         dependencies.append(dep)
 
+    # SCHEMA-SYNC (#82): use SCHEMA_VERSION constant so template exports
+    # stay in step with model parser expectations across releases.
     return {
-        "schema_version": "3.0",
+        "schema_version": SCHEMA_VERSION,
         "components": components,
         "dependencies": dependencies,
     }

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -281,9 +281,13 @@ class TestOpenAPIDocs:
         assert data["info"]["title"] == "FaultRay API"
 
     def test_openapi_version(self, client):
+        # VERSION-SYNC (#101): OpenAPI version must reflect the current
+        # faultray package version (kept in sync via pyproject.toml).
+        from faultray import __version__ as _fv
+
         resp = client.get("/openapi.json")
         data = resp.json()
-        assert data["info"]["version"] == "10.3.0"
+        assert data["info"]["version"] == _fv
 
     def test_openapi_contact_info(self, client):
         resp = client.get("/openapi.json")

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -1,0 +1,73 @@
+"""Regression tests: prevent schema / OpenAPI version drift (#82, #101).
+
+CHANGELOG announced schema v4.0, but init_cmd / gallery kept emitting
+"3.0"; openapi_config also drifted to "10.3.0" while pyproject was at
+11.2.0. This test locks both in sync.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _pyproject_version() -> str:
+    with open(_PROJECT_ROOT / "pyproject.toml", "rb") as f:
+        return tomllib.load(f)["project"]["version"]
+
+
+def test_package_dunder_version_matches_pyproject():
+    from faultray import __version__
+
+    assert __version__ == _pyproject_version(), (
+        f"__init__.__version__ ({__version__}) is out of sync with "
+        f"pyproject.toml ({_pyproject_version()})"
+    )
+
+
+def test_openapi_config_reflects_package_version():
+    from faultray import __version__
+    from faultray.api.openapi_config import OPENAPI_CONFIG
+
+    assert OPENAPI_CONFIG["version"] == __version__, (
+        f"OPENAPI_CONFIG['version'] ({OPENAPI_CONFIG['version']}) must "
+        f"reference faultray.__version__ ({__version__}) to prevent drift"
+    )
+
+
+def test_init_cmd_uses_schema_version_constant():
+    """faultray init must emit SCHEMA_VERSION from model.components."""
+    from faultray.model.components import SCHEMA_VERSION
+
+    src = (_PROJECT_ROOT / "src/faultray/cli/init_cmd.py").read_text()
+    # Must NOT contain hardcoded "schema_version": "3.0"
+    assert '"schema_version": "3.0"' not in src, (
+        "init_cmd.py still hardcodes schema_version='3.0' — should use SCHEMA_VERSION constant"
+    )
+    # Must import SCHEMA_VERSION
+    assert "SCHEMA_VERSION" in src, (
+        "init_cmd.py must reference SCHEMA_VERSION from model.components"
+    )
+    assert SCHEMA_VERSION  # ensure constant is importable
+
+
+def test_gallery_uses_schema_version_constant():
+    import yaml
+
+    from faultray.model.components import SCHEMA_VERSION
+    from faultray.templates.gallery import TemplateGallery
+
+    gallery = TemplateGallery()
+    names = gallery.list_templates()
+    assert names, "TemplateGallery returned empty list — nothing to verify"
+
+    template_id = names[0].id
+    yaml_str = gallery.to_yaml(template_id)
+    yaml_dict = yaml.safe_load(yaml_str)
+    assert yaml_dict["schema_version"] == SCHEMA_VERSION, (
+        f"gallery emitted {yaml_dict['schema_version']!r}, expected "
+        f"SCHEMA_VERSION ({SCHEMA_VERSION!r})"
+    )


### PR DESCRIPTION
## Summary
2 件の version drift を1 PR で解消。

### #82 schema_version drift
- CHANGELOG は v4.0 を announce 済み / \`SCHEMA_VERSION=\"4.0\"\` が権威
- しかし \`init_cmd.py:380\` と \`gallery.py:2050\` は \`\"3.0\"\` を hardcoded
- Fix: 両方とも \`model.components.SCHEMA_VERSION\` を import 参照

### #101 OpenAPI version drift
- \`pyproject.toml\` / \`faultray.__version__\` = 11.2.0
- しかし \`openapi_config.py:59\` は \`\"10.3.0\"\` のまま
- Fix: \`from faultray import __version__\` し config が \`__version__\` 参照

## テスト

**新規**: \`tests/test_version_sync.py\` (4 regression ガード)
- \`__version__\` ↔ \`pyproject.toml[project].version\` 一致
- \`OPENAPI_CONFIG[\"version\"]\` が \`__version__\` と等しい
- \`init_cmd.py\` に hardcoded \`\"3.0\"\` が残っていない + SCHEMA_VERSION import 確認
- \`gallery.to_yaml()\` 出力の \`schema_version\` が SCHEMA_VERSION 一致

**更新**: \`tests/test_api_v1.py::test_openapi_version\`
- hardcoded \`\"10.3.0\"\` 文字列を \`faultray.__version__\` 参照に変更

ローカル実行: **17/17 pass**

Closes #82, #101.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray/pull/111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Version synchronization across API configuration and application components now uses dynamic runtime values instead of hardcoded versions, ensuring consistency throughout the application.

* **Tests**
  * Added comprehensive regression tests to validate version consistency across multiple components and prevent version drift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->