### PR TITLE
chore(deps): document requirements.txt as Streamlit Cloud manifest only (#85)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,12 @@ pdf = [
 mcp = [
     "mcp>=1.0,<1.28",
 ]
+# Streamlit UI (ui/streamlit_app.py). Mirrors the minimum set of runtime
+# deps that the Streamlit Cloud manifest (requirements.txt) also lists,
+# so `pip install -e ".[streamlit]"` reproduces that environment locally.
+streamlit = [
+    "streamlit>=1.35.0",
+]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,23 @@
-# Streamlit Cloud用
+# ============================================================
+# Streamlit Cloud deployment manifest ONLY.
+#
+# ⚠️  DO NOT USE FOR DEVELOPMENT.
+#     The canonical dependency source of truth is `pyproject.toml`.
+#     For local development run: `pip install -e ".[dev]"` (or `uv sync`).
+#
+# Streamlit Cloud resolves top-level `requirements.txt` by convention
+# (https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/app-dependencies).
+# This file lists the **minimum** runtime deps for the Streamlit UI
+# (`ui/streamlit_app.py`) to boot on Streamlit Cloud. It intentionally
+# omits server-side deps (fastapi, sqlalchemy, aiosqlite, defusedxml,
+# authlib, ...) pinned in pyproject.toml — those are not needed for the
+# read-only Streamlit front-end.
+#
+# To add a runtime dep here:
+#   1. Confirm the Streamlit UI imports it at runtime (skip if not).
+#   2. Add it to pyproject.toml first; only mirror here if (1) holds.
+# Rationale: #85 (avoid drift between manifest and pyproject).
+# ============================================================
 streamlit>=1.35.0
 pyyaml>=6.0
 networkx>=3.0

--- a/tests/test_requirements_subset.py
+++ b/tests/test_requirements_subset.py
@@ -1,0 +1,75 @@
+"""Lock in the requirements.txt <-> pyproject.toml contract (#85).
+
+requirements.txt is the Streamlit Cloud deployment manifest only. Every
+dep listed there must also be declared in pyproject.toml, otherwise we
+have drift that will bite us in the Streamlit Cloud build.
+
+(The reverse is NOT required — pyproject.toml has server-side deps that
+aren't needed for the Streamlit UI.)
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _parse_requirements(path: Path) -> set[str]:
+    pkgs: set[str] = set()
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        # strip version spec: "streamlit>=1.35.0" -> "streamlit"
+        m = re.match(r"^([A-Za-z0-9][A-Za-z0-9_.\-]*)", line)
+        if m:
+            pkgs.add(m.group(1).lower().replace("_", "-"))
+    return pkgs
+
+
+def _parse_pyproject_deps(path: Path) -> set[str]:
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+    deps: list[str] = data["project"].get("dependencies", [])
+    out: set[str] = set()
+    for raw in deps:
+        m = re.match(r"^([A-Za-z0-9][A-Za-z0-9_.\-]*)", raw)
+        if m:
+            out.add(m.group(1).lower().replace("_", "-"))
+    # Optional deps (project.optional-dependencies.*) also count
+    for _group, entries in (data["project"].get("optional-dependencies", {}) or {}).items():
+        for raw in entries:
+            m = re.match(r"^([A-Za-z0-9][A-Za-z0-9_.\-]*)", raw)
+            if m:
+                out.add(m.group(1).lower().replace("_", "-"))
+    return out
+
+
+def test_requirements_txt_is_subset_of_pyproject():
+    """Every dep in requirements.txt must also live in pyproject.toml."""
+    req = _parse_requirements(_PROJECT_ROOT / "requirements.txt")
+    pyp = _parse_pyproject_deps(_PROJECT_ROOT / "pyproject.toml")
+    missing = req - pyp
+    assert not missing, (
+        f"requirements.txt drifted from pyproject.toml — these deps are "
+        f"listed in requirements.txt but NOT declared in pyproject.toml: "
+        f"{sorted(missing)}. Add them to pyproject.toml first, then mirror "
+        f"here only if the Streamlit UI actually imports them at runtime."
+    )
+
+
+def test_requirements_txt_documents_its_purpose():
+    """Guard against 'just delete the comments' regressions."""
+    text = (_PROJECT_ROOT / "requirements.txt").read_text(encoding="utf-8")
+    assert "Streamlit Cloud" in text, (
+        "requirements.txt must document that it is the Streamlit Cloud "
+        "manifest (see #85). pyproject.toml is the canonical dep source."
+    )
+    assert "pyproject.toml" in text, (
+        "requirements.txt comment must point developers at pyproject.toml "
+        "for local dev."
+    )


### PR DESCRIPTION
## Summary
`requirements.txt` と `pyproject.toml` の divergent を解消。

**削除しない理由**: Streamlit Cloud は慣例的に top-level `requirements.txt` を参照するため、削除すると deploy を壊す。

## 変更
- `requirements.txt` 冒頭に用途を明記するコメントブロック:
  - 「Streamlit Cloud deployment manifest ONLY」
  - 開発は `pip install -e ".[dev]"` (pyproject.toml が canonical source)
  - 追加 dep は pyproject.toml に先に入れ、Streamlit UI が runtime で import する場合のみ mirror
- `pyproject.toml` に optional group `streamlit = ["streamlit>=1.35.0"]` 追加
  - `pip install -e ".[streamlit]"` で local にも Streamlit UI 環境を再現可
- `tests/test_requirements_subset.py` 新規 (2 regression ガード):
  - requirements.txt の全 dep が pyproject.toml (main + optional 含む) の subset であることを assert
  - comment に "Streamlit Cloud" / "pyproject.toml" 文字列が残ることを保証

Closes #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray/pull/113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
