### PR TITLE
test(monkey): register pytest marker + opt-in CI wrapper (#84)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,14 @@ jobs:
         run: pytest tests/test_property_based.py -v --tb=short --noconftest
 
       - name: Run tests
+        # TEST-MARKER (#84): exclude opt-in markers by default. Monkey
+        # tests need a running Streamlit server; integration needs kind
+        # / docker; both are unsuitable for the default CI leg. Run
+        # explicitly with `pytest -m monkey` / `pytest -m integration`.
         run: |
-          pytest -v --tb=short --junitxml=test-results.xml 2>&1 | tee test-output.txt
+          pytest -v --tb=short --junitxml=test-results.xml \
+            -m "not monkey and not integration" \
+            2>&1 | tee test-output.txt
           EXIT_CODE=${PIPESTATUS[0]}
 
           echo ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ asyncio_mode = "auto"
 markers = [
     "e2e: end-to-end tests",
     "integration: integration tests requiring external services (kind/docker/kubectl etc.)",
+    "monkey: random-action UI monkey tests (require Streamlit server running at localhost:8501; opt-in via `pytest -m monkey`)",
 ]
 
 [tool.mypy]

--- a/tests/monkey_test.py
+++ b/tests/monkey_test.py
@@ -345,6 +345,20 @@ def run_monkey_test():
     return total_issues
 
 
+# ============================================================
+# Pytest wrapper (#84): expose the monkey runner as an opt-in test.
+# Default CI excludes this via `-m "not monkey"`; run explicitly with
+#   pytest -m monkey tests/monkey_test.py
+# Requires a Streamlit server at BASE_URL.
+# ============================================================
+
+@pytest.mark.monkey
+def test_monkey_no_errors_found() -> None:
+    """Run the UI monkey runner and fail if any crash / error was recorded."""
+    issues = run_monkey_test()
+    assert issues == 0, f"monkey runner detected {issues} issue(s); see console output"
+
+
 if __name__ == "__main__":
     issues = run_monkey_test()
     exit(1 if issues > 0 else 0)


### PR DESCRIPTION
## Summary
`tests/monkey_test.py` に pytest marker が無く、CI で selective に include/exclude できなかった。更に実体 `run_monkey_test()` は `if __name__ == '__main__'` 下の script-only で pytest 経由で走らず、**自動ランダム UI 試験 (SQLi / XSS / path traversal 等) が CI gate に載っていなかった**。

## 変更
- `pyproject.toml` の `markers` に `monkey` を登録
- `tests/monkey_test.py` に `@pytest.mark.monkey` 付き `test_monkey_no_errors_found` wrapper を追加 (`run_monkey_test()` を呼び、戻り値 issues が 0 以外なら fail)
- `.github/workflows/ci.yml` の `pytest` 起動に `-m "not monkey and not integration"` を明示 (monkey は Streamlit server、integration は kind/docker 依存)

## 実行方法
```
pytest -m monkey tests/monkey_test.py   # Streamlit @ localhost:8501 が必要
pytest -m "not monkey and not integration"  # default CI
```

## ローカル検証
- `pytest tests/monkey_test.py --collect-only` → 1 test 収集
- `pytest -m "not monkey and not integration" --collect-only` → 3 deselected (1 monkey + 2 integration)
- `pytest -m monkey --collect-only` → 1 / 33867 collected

Closes #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray/pull/114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
