### PR TITLE
legal: set Effective Date + add Version field to privacy/ToS (#94)

### DIFF
--- a/docs/legal/privacy-policy.md
+++ b/docs/legal/privacy-policy.md
@@ -1,7 +1,8 @@
 # FaultRay Privacy Policy
 
-**Effective Date:** [To be determined]
-**Last Updated:** 2026-03-16
+**Effective Date:** 2026-04-22
+**Last Updated:** 2026-04-22
+**Version:** 1.0
 
 ---
 

--- a/docs/legal/privacy-policy/index.html
+++ b/docs/legal/privacy-policy/index.html
@@ -2429,8 +2429,9 @@
 <p><strong>DRAFT -- Not yet reviewed by legal counsel.</strong>
 This document is a working draft and does not constitute a binding privacy policy until formally reviewed, approved, and published by qualified legal counsel.</p>
 </blockquote>
-<p><strong>Effective Date:</strong> [To be determined]
-<strong>Last Updated:</strong> 2026-03-16</p>
+<p><strong>Effective Date:</strong> 2026-04-22
+<strong>Last Updated:</strong> 2026-04-22
+<strong>Version:</strong> 1.0</p>
 <hr />
 <h2 id="introduction">Introduction</h2>
 <p>This Privacy Policy describes how Yutaro Maeda and FaultRay Contributors ("we," "us," or "the Company") collect, use, store, and protect information when you use the FaultRay platform and related services (collectively, "the Service").</p>

--- a/docs/legal/terms-of-service.md
+++ b/docs/legal/terms-of-service.md
@@ -1,7 +1,8 @@
 # FaultRay Terms of Service
 
-**Effective Date:** [To be determined]
-**Last Updated:** 2026-03-16
+**Effective Date:** 2026-04-22
+**Last Updated:** 2026-04-22
+**Version:** 1.0
 
 ---
 

--- a/docs/legal/terms-of-service/index.html
+++ b/docs/legal/terms-of-service/index.html
@@ -2641,8 +2641,9 @@
 <p><strong>DRAFT -- Not yet reviewed by legal counsel.</strong>
 This document is a working draft and does not constitute a binding legal agreement until formally reviewed, approved, and published by qualified legal counsel.</p>
 </blockquote>
-<p><strong>Effective Date:</strong> [To be determined]
-<strong>Last Updated:</strong> 2026-03-16</p>
+<p><strong>Effective Date:</strong> 2026-04-22
+<strong>Last Updated:</strong> 2026-04-22
+<strong>Version:</strong> 1.0</p>
 <hr />
 <h2 id="1-description-of-service">1. Description of Service</h2>
 <p>FaultRay ("the Service") is a zero-risk infrastructure chaos simulation platform provided by Yutaro Maeda and FaultRay Contributors ("we," "us," or "the Company"). The Service enables users to:</p>

--- a/tests/test_legal_effective_date.py
+++ b/tests/test_legal_effective_date.py
@@ -1,0 +1,57 @@
+"""Regression tests for legal policy headers (#94).
+
+Guards docs/legal/*.md and rendered docs/legal/**/index.html from
+regressing to '[To be determined]' placeholder for Effective Date, and
+ensures both files carry a Version field for audit trail.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_LEGAL = _ROOT / "docs" / "legal"
+
+_POLICY_FILES = [
+    _LEGAL / "privacy-policy.md",
+    _LEGAL / "terms-of-service.md",
+    _LEGAL / "privacy-policy" / "index.html",
+    _LEGAL / "terms-of-service" / "index.html",
+]
+
+_ISO_DATE = re.compile(r"\b\d{4}-\d{2}-\d{2}\b")
+
+
+@pytest.mark.parametrize("path", _POLICY_FILES)
+def test_no_placeholder_effective_date(path: Path):
+    assert path.exists(), f"expected legal file missing: {path}"
+    text = path.read_text(encoding="utf-8")
+    assert "[To be determined]" not in text, (
+        f"{path.name} still contains '[To be determined]' placeholder "
+        f"for a dated field — set a real ISO date (#94)"
+    )
+
+
+@pytest.mark.parametrize("path", _POLICY_FILES)
+def test_effective_date_is_iso_format(path: Path):
+    text = path.read_text(encoding="utf-8")
+    # Markdown: **Effective Date:** 2026-04-22
+    # HTML:     <strong>Effective Date:</strong> 2026-04-22
+    m = re.search(r"Effective Date:\s*(?:</strong>)?\s*\**\s*(\d{4}-\d{2}-\d{2})", text)
+    assert m, f"{path.name}: could not find 'Effective Date: YYYY-MM-DD'"
+    assert _ISO_DATE.fullmatch(m.group(1)), (
+        f"{path.name}: Effective Date must be ISO yyyy-mm-dd, got {m.group(1)!r}"
+    )
+
+
+@pytest.mark.parametrize("path", _POLICY_FILES)
+def test_version_field_present(path: Path):
+    text = path.read_text(encoding="utf-8")
+    # Markdown: **Version:** 1.0
+    # HTML:     <strong>Version:</strong> 1.0
+    assert re.search(r"Version:\s*(?:</strong>)?\s*\**\s*\d+(?:\.\d+)*", text), (
+        f"{path.name}: expected a 'Version: X.Y' line for audit trail (#94)"
+    )


### PR DESCRIPTION
## Summary
privacy-policy / terms-of-service の 4 ファイルで `Effective Date: [To be determined]` がプレースホルダのまま残っており、GDPR / APPI 上 policy が **enforceable でない** 状態だった (EU は有効日がないと binding にならない)。

## 変更
- `docs/legal/privacy-policy.md`
- `docs/legal/terms-of-service.md`
- `docs/legal/privacy-policy/index.html` (mkdocs rendered)
- `docs/legal/terms-of-service/index.html` (mkdocs rendered)

いずれも:
- Effective Date: **2026-04-22**
- Last Updated: 2026-04-22
- Version: **1.0** (監査用 audit trail の起点)

## Regression lock
`tests/test_legal_effective_date.py` (12 ケース)
- `[To be determined]` が混入しないこと
- Effective Date が ISO 8601 (`YYYY-MM-DD`) 形式
- `Version: X.Y` 行の存在

Closes #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray/pull/115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Privacy Policy and Terms of Service now include official effective dates (2026-04-22) and Version 1.0 designation. Placeholder text replaced with concrete dates.

* **Tests**
  * Added tests to validate legal document metadata, ensuring effective dates are properly formatted and version information is present across all policy documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->