### PR TITLE
test(security): lock defusedxml migration with regression guard (#91)

### DIFF
--- a/tests/test_defusedxml_coverage.py
+++ b/tests/test_defusedxml_coverage.py
@@ -1,0 +1,74 @@
+"""Regression: block unsafe stdlib `xml.*` parser imports (#91).
+
+v11.2.0 migrated all XML parsing to defusedxml to close XXE / Billion
+Laughs vectors. This test guards against regressions — a future commit
+accidentally reintroducing `xml.etree.ElementTree.parse` / `.fromstring`
+or `xml.sax.make_parser` would silently reopen the attack surface.
+
+Allowlist (legitimate non-parsing uses):
+  - xml.etree.ElementTree.Element  (type-annotation only, no parser)
+  - xml.sax.saxutils.escape         (pure string escape helper)
+  - xml.sax.saxutils.quoteattr      (pure string escape helper)
+
+Anything else from `xml.*` is considered unsafe by default.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent.parent / "src" / "faultray"
+
+_ALLOWED_IMPORTS: set[str] = {
+    # Pattern -> rationale (for maintainer review if this test fires).
+    "from xml.etree.ElementTree import Element as _XMLElement",
+    "from xml.sax.saxutils import escape",
+    "from xml.sax.saxutils import escape as _xml_escape",
+}
+
+_XML_IMPORT_RE = re.compile(r"^(?:from|import)\s+xml(?:\.|$|\s)", re.MULTILINE)
+
+
+def _python_files():
+    return list(_SRC.rglob("*.py"))
+
+
+def test_no_unsafe_xml_imports_in_src():
+    """All `xml.*` imports in src/ must appear in the allowlist."""
+    offenders: list[tuple[Path, str]] = []
+    for py in _python_files():
+        text = py.read_text(encoding="utf-8")
+        for m in _XML_IMPORT_RE.finditer(text):
+            # Extract the full line so we can match against the allowlist.
+            line_start = text.rfind("\n", 0, m.start()) + 1
+            line_end = text.find("\n", m.start())
+            if line_end == -1:
+                line_end = len(text)
+            line = text[line_start:line_end].strip()
+            # Skip comments (e.g. in docstrings)
+            if line.startswith("#"):
+                continue
+            if line not in _ALLOWED_IMPORTS:
+                offenders.append((py.relative_to(_SRC.parent), line))
+
+    if offenders:
+        lines = "\n".join(f"  {p}: {l}" for p, l in offenders)
+        raise AssertionError(
+            "unsafe stdlib xml.* imports detected (use defusedxml instead, "
+            "or add to _ALLOWED_IMPORTS if a non-parsing use):\n" + lines
+        )
+
+
+def test_defusedxml_is_pinned_in_dependencies():
+    """defusedxml must stay in pyproject.toml runtime deps."""
+    import tomllib
+
+    pyproject = _SRC.parent.parent / "pyproject.toml"
+    with open(pyproject, "rb") as f:
+        data = tomllib.load(f)
+    deps = data["project"]["dependencies"]
+    assert any(d.startswith("defusedxml") for d in deps), (
+        "defusedxml must remain in [project].dependencies to preserve "
+        "the XXE / Billion-Laughs hardening done in v11.2.0 (#91)"
+    )


### PR DESCRIPTION
## Summary
v11.2.0 で stdlib `xml.*` → `defusedxml` の移行を完了したが、**後から誰かが `xml.etree.ElementTree.parse()` を書いても CI で検出されない**状態が残っていた (XXE / Billion Laughs 攻撃面の silent 再オープンリスク)。

## 変更
`tests/test_defusedxml_coverage.py` (2 regression ケース):
1. **src/ の全 .py から `xml.*` import 行を抽出し、allowlist 外なら fail**
   - allowlist: 非 parser 用途の 3 行のみ
     - `xml.etree.ElementTree.Element` (型注釈専用)
     - `xml.sax.saxutils.escape` (純 string escape)
     - `xml.sax.saxutils.escape as _xml_escape`
2. **`defusedxml` が pyproject.toml [project].dependencies に残存することを保証** (optional group に移動される事故を防止)

ローカル実行: 2/2 pass

Closes #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
