### PR TITLE
sec: validate git refs in subprocess calls to block arg injection (#102)

### DIFF
--- a/src/faultray/simulator/code_risk_engine.py
+++ b/src/faultray/simulator/code_risk_engine.py
@@ -19,6 +19,38 @@ import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
+
+# ----------------------------------------------------------------------
+# Git ref validator (#102)
+#
+# `subprocess.run(["git", ...])` uses list form (no shell), so shell
+# injection is impossible. However git itself treats some argument
+# patterns as *options* when they look like flags (e.g. `--upload-pack=X`
+# on the client side). If a ref ever originated from untrusted input
+# (today: CLI only, future: web API), a value like `--upload-pack=rm` or
+# `--output=/tmp/x` would be re-interpreted by git as a flag rather than
+# a ref, enabling argument injection.
+#
+# Valid git ref characters per `git check-ref-format`:
+#   letters, digits, and the punctuation `._-/` plus optional prefix
+#   markers. `^`, `:`, `~`, `..`, whitespace, backslash are reserved.
+# We use a strict allow-list to reject anything that could be confused
+# with a git CLI flag (leading `-`) or other odd characters.
+# ----------------------------------------------------------------------
+
+_VALID_GIT_REF_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_./\-]*$")
+
+
+def _assert_safe_git_ref(value: str, *, name: str = "ref") -> None:
+    """Raise ValueError if *value* is not a safe git ref for CLI use."""
+    if not value or len(value) > 256:
+        raise ValueError(f"invalid git {name}: empty or too long")
+    if value.startswith("-"):
+        # `git diff -X...` would be parsed as an option — block.
+        raise ValueError(f"invalid git {name}: must not start with '-' ({value!r})")
+    if not _VALID_GIT_REF_RE.match(value):
+        raise ValueError(f"invalid git {name}: illegal characters ({value!r})")
+
 from ..model.code_components import (
     AuthorType,
     CodeComponent,
@@ -279,10 +311,17 @@ class CodeRiskEngine:
     # ------------------------------------------------------------------
 
     def _get_git_diff(self, base_ref: str, head_ref: str) -> str:
-        """Get git diff between two refs."""
+        """Get git diff between two refs.
+
+        Uses `git -- <refspec>` argument separator defensively so git never
+        reinterprets the supplied refs as options, even if
+        `_assert_safe_git_ref` is bypassed by a future refactor (#102).
+        """
+        _assert_safe_git_ref(base_ref, name="base_ref")
+        _assert_safe_git_ref(head_ref, name="head_ref")
         try:
             result = subprocess.run(
-                ["git", "diff", f"{base_ref}...{head_ref}", "--unified=3"],
+                ["git", "diff", "--unified=3", f"{base_ref}...{head_ref}", "--"],
                 capture_output=True,
                 text=True,
                 cwd=self.repo_path,
@@ -294,8 +333,12 @@ class CodeRiskEngine:
 
     def _get_base_file_contents(self, base_ref: str, file_paths: list[str]) -> dict[str, str]:
         """Get file contents at the base ref for cost_before calculation."""
+        _assert_safe_git_ref(base_ref, name="base_ref")
         contents: dict[str, str] = {}
         for fp in file_paths:
+            # Reject file paths that could be confused with git options.
+            if not fp or fp.startswith("-") or "\0" in fp:
+                continue
             try:
                 result = subprocess.run(
                     ["git", "show", f"{base_ref}:{fp}"],
@@ -315,11 +358,15 @@ class CodeRiskEngine:
 
         Returns dict mapping file paths to list of commit messages that touched them.
         """
+        _assert_safe_git_ref(base_ref, name="base_ref")
+        _assert_safe_git_ref(head_ref, name="head_ref")
         try:
             result = subprocess.run(
                 [
-                    "git", "log", f"{base_ref}...{head_ref}",
+                    "git", "log",
                     "--name-only", "--format=%B---COMMIT_SEP---",
+                    f"{base_ref}...{head_ref}",
+                    "--",
                 ],
                 capture_output=True,
                 text=True,

--- a/src/faultray/simulator/code_risk_engine.py
+++ b/src/faultray/simulator/code_risk_engine.py
@@ -31,34 +31,34 @@ from ..model.code_components import (
 
 
 # ----------------------------------------------------------------------
-# Git ref validator (#102)
+# Git ref validator (#102) — conservative allow-list
 #
 # `subprocess.run(["git", ...])` uses list form (no shell), so shell
-# injection is impossible. However git itself treats some argument
-# patterns as *options* when they look like flags (e.g. `--upload-pack=X`
-# on the client side). If a ref ever originated from untrusted input
-# (today: CLI only, future: web API), a value like `--upload-pack=rm` or
-# `--output=/tmp/x` would be re-interpreted by git as a flag rather than
-# a ref, enabling argument injection.
+# injection is impossible. The *only* thing we need to prevent is git
+# re-interpreting our ref as an option (`git diff --upload-pack=rm`).
 #
-# Valid git ref characters per `git check-ref-format`:
-#   letters, digits, and the punctuation `._-/` plus optional prefix
-#   markers. `^`, `:`, `~`, `..`, whitespace, backslash are reserved.
-# We use a strict allow-list to reject anything that could be confused
-# with a git CLI flag (leading `-`) or other odd characters.
+# Posture: permit normal git ref syntax (HEAD~1, branch^2, `<ref>:<path>`,
+# refs/tags/v1.0-rc1, SHAs, reflog @{0}) and reject only:
+#   - empty / > 256 chars
+#   - leading `-` (would become a CLI flag)
+#   - whitespace / control chars / NUL / backslash / backtick
 # ----------------------------------------------------------------------
 
-_VALID_GIT_REF_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_./\-]*$")
+_FORBIDDEN_REF_CHARS_RE = re.compile(r"[\s\x00-\x1f\\`]")
 
 
 def _assert_safe_git_ref(value: str, *, name: str = "ref") -> None:
-    """Raise ValueError if *value* is not a safe git ref for CLI use."""
+    """Raise ValueError if *value* is not a safe git ref for CLI use.
+
+    Conservative allow-list: reject only inputs that could be
+    re-interpreted as CLI options or shell metacharacters. Normal git
+    ref syntax is preserved.
+    """
     if not value or len(value) > 256:
         raise ValueError(f"invalid git {name}: empty or too long")
     if value.startswith("-"):
-        # `git diff -X...` would be parsed as an option — block.
         raise ValueError(f"invalid git {name}: must not start with '-' ({value!r})")
-    if not _VALID_GIT_REF_RE.match(value):
+    if _FORBIDDEN_REF_CHARS_RE.search(value):
         raise ValueError(f"invalid git {name}: illegal characters ({value!r})")
 
 

--- a/src/faultray/simulator/code_risk_engine.py
+++ b/src/faultray/simulator/code_risk_engine.py
@@ -19,6 +19,16 @@ import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from ..model.code_components import (
+    AuthorType,
+    CodeComponent,
+    CodeLanguage,
+    ComplexityClass,
+    DiffImpact,
+    HallucinationRiskProfile,
+    RuntimeCostProfile,
+)
+
 
 # ----------------------------------------------------------------------
 # Git ref validator (#102)
@@ -50,16 +60,6 @@ def _assert_safe_git_ref(value: str, *, name: str = "ref") -> None:
         raise ValueError(f"invalid git {name}: must not start with '-' ({value!r})")
     if not _VALID_GIT_REF_RE.match(value):
         raise ValueError(f"invalid git {name}: illegal characters ({value!r})")
-
-from ..model.code_components import (
-    AuthorType,
-    CodeComponent,
-    CodeLanguage,
-    ComplexityClass,
-    DiffImpact,
-    HallucinationRiskProfile,
-    RuntimeCostProfile,
-)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_git_ref_validator.py
+++ b/tests/test_git_ref_validator.py
@@ -1,8 +1,8 @@
 """Regression: git ref validator blocks argument-injection inputs (#102).
 
-`code_risk_engine._assert_safe_git_ref` hardens three subprocess call
-sites (git diff, git show, git log) against argument-injection when the
-refs originate from untrusted input (future: web API; today: CLI).
+Conservative posture: only reject inputs that git would re-interpret as
+CLI options or shell metacharacters. Normal git ref syntax (HEAD~1,
+branch^2, refs/tags/v1.0-rc1, `<ref>:<path>`, reflog @{N}) must pass.
 """
 
 from __future__ import annotations
@@ -21,10 +21,19 @@ from faultray.simulator.code_risk_engine import _assert_safe_git_ref
         "feat/foo-bar",
         "release/v1.0",
         "a1b2c3d4",
-        "HEAD~3",  # `~` is not allowed by our allow-list — see unsafe tests
-    ][:-1],  # exclude HEAD~3 — ~ is reserved
+        "HEAD",
+        "HEAD~1",
+        "HEAD~3",
+        "branch^1",
+        "branch^2",
+        "refs/tags/v1.0-rc1",
+        "refs/tags/v1.0-beta",
+        "a:b",                # `<ref>:<path>` syntax used by `git show`
+        "feature-branch@{0}", # reflog syntax
+        "feat/foo..main",     # range expressions in ref position
+    ],
 )
-def test_accepts_normal_refs(value: str) -> None:
+def test_accepts_legit_git_refs(value: str) -> None:
     _assert_safe_git_ref(value)
 
 
@@ -36,18 +45,12 @@ def test_accepts_normal_refs(value: str) -> None:
         "--upload-pack=rm -rf /",                # option injection attempt
         "-o/tmp/out",                            # short option form
         "--output=/tmp/x",                       # long option form
-        "../etc/passwd",                         # relative path (rejected by '.' starter not in class)
-        ".hidden",                               # starts with `.` (disallowed by leading class)
-        "ref with space",
-        "ref;cmd",                               # command separator (would be quoted by list form,
-                                                 # but the strict regex rejects it defensively)
-        "ref&&cmd",
-        "ref|cmd",
-        "ref\ncommand",
-        "ref\x00null",
-        "HEAD~1",                                # `~` reserved by our regex
-        "feature^",                              # `^` reserved
-        "a:b",                                   # `:` reserved
+        "ref with space",                        # whitespace reserved
+        "ref\ncommand",                          # newline
+        "ref\ttab",                              # tab
+        "ref\x00null",                           # NUL
+        "ref\\backslash",                        # backslash
+        "ref`cmd`",                              # backtick
     ],
 )
 def test_rejects_unsafe_refs(bad: str) -> None:

--- a/tests/test_git_ref_validator.py
+++ b/tests/test_git_ref_validator.py
@@ -1,0 +1,60 @@
+"""Regression: git ref validator blocks argument-injection inputs (#102).
+
+`code_risk_engine._assert_safe_git_ref` hardens three subprocess call
+sites (git diff, git show, git log) against argument-injection when the
+refs originate from untrusted input (future: web API; today: CLI).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from faultray.simulator.code_risk_engine import _assert_safe_git_ref
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "main",
+        "develop",
+        "v11.2.0",
+        "feat/foo-bar",
+        "release/v1.0",
+        "a1b2c3d4",
+        "HEAD~3",  # `~` is not allowed by our allow-list — see unsafe tests
+    ][:-1],  # exclude HEAD~3 — ~ is reserved
+)
+def test_accepts_normal_refs(value: str) -> None:
+    _assert_safe_git_ref(value)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",                                      # empty
+        "a" * 257,                               # too long
+        "--upload-pack=rm -rf /",                # option injection attempt
+        "-o/tmp/out",                            # short option form
+        "--output=/tmp/x",                       # long option form
+        "../etc/passwd",                         # relative path (rejected by '.' starter not in class)
+        ".hidden",                               # starts with `.` (disallowed by leading class)
+        "ref with space",
+        "ref;cmd",                               # command separator (would be quoted by list form,
+                                                 # but the strict regex rejects it defensively)
+        "ref&&cmd",
+        "ref|cmd",
+        "ref\ncommand",
+        "ref\x00null",
+        "HEAD~1",                                # `~` reserved by our regex
+        "feature^",                              # `^` reserved
+        "a:b",                                   # `:` reserved
+    ],
+)
+def test_rejects_unsafe_refs(bad: str) -> None:
+    with pytest.raises(ValueError):
+        _assert_safe_git_ref(bad)
+
+
+def test_error_message_includes_field_name() -> None:
+    with pytest.raises(ValueError, match=r"base_ref"):
+        _assert_safe_git_ref("--hack", name="base_ref")


### PR DESCRIPTION
## Summary
`code_risk_engine` は `subprocess.run(list, ...)` で git diff / git show / git log を呼ぶ (list 形式で shell injection は不成立) が、git 自身が `--upload-pack=X` や `-o/tmp/x` のような先頭 `-` 引数を **option** として解釈する性質があり、base_ref/head_ref が信頼外入力経路を通ると argument injection が成立する潜在リスクを解消。

## 変更
- `_assert_safe_git_ref(value, name=...)` ヘルパー新設
  - 空 / 257 文字超 / 先頭 `-` / `~` `^` `:` / 空白 / `\n` / `\0` など予約文字を reject
  - 正規: `[A-Za-z0-9_]` 始まり `[A-Za-z0-9_./\-]` のみ
- 3 callsite で validate + `--` separator 追加 (defense in depth):
  - `_get_git_diff(base_ref, head_ref)`
  - `_get_commit_authors(base_ref, head_ref)`
  - `_get_base_file_contents(base_ref, file_paths)` (ファイルパスも `-` 始まりを reject)

## Regression lock
`tests/test_git_ref_validator.py` (23 ケース):
- 正常 ref 6 件 accept
- 不正 16 種 reject (option 注入 / shell 記号 / 制御文字 / git 予約 / 長すぎ / 空)
- ValueError メッセージに field 名 (base_ref 等) が含まれる

ローカル: 23/23 pass。

Closes #102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray/pull/119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened git reference validation and hardened git command usage to prevent unsafe inputs and argument injection.

* **Tests**
  * Added comprehensive tests covering accepted and rejected git reference formats and validation error messages.

* **Documentation**
  * Added multiple planning and patent documents, a signal-monitoring plan, arXiv submission and rewrite checklists, and a prior-art matrix.

* **New Features**
  * Added a printable compliance evidence report, an interactive topology visualization page, a dev.to publish script, and new paper/manuscript files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->