### PR TITLE
perf(api): RateLimiter periodic expired-sweep bounds memory (#103)

### DIFF
--- a/src/faultray/api/server.py
+++ b/src/faultray/api/server.py
@@ -35,7 +35,19 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 class RateLimiter:
-    """Simple in-memory rate limiter using a sliding window."""
+    """Simple in-memory rate limiter using a sliding window.
+
+    Memory posture (#103):
+    - Hard cap: MAX_KEYS (10_000) forces immediate eviction.
+    - Soft cap: CLEANUP_INTERVAL_SECONDS (30s) triggers an expired-sweep
+      on the next is_allowed() call after the interval elapses.
+    - Trade-off: cleanup is call-driven, not timer-driven. If traffic
+      drops to zero, no sweep runs until the next request. Worst-case
+      memory footprint is therefore bounded by MAX_KEYS * avg_list_size,
+      not by wall-clock time. This is intentional — a background thread
+      would complicate FastAPI lifespan management for negligible memory
+      savings (10K keys ≈ 1–2 MB).
+    """
 
     MAX_KEYS = 10_000  # prevent unbounded memory growth
     CLEANUP_INTERVAL_SECONDS = 30  # #103: run expired-sweep at least this often

--- a/src/faultray/api/server.py
+++ b/src/faultray/api/server.py
@@ -38,12 +38,14 @@ class RateLimiter:
     """Simple in-memory rate limiter using a sliding window."""
 
     MAX_KEYS = 10_000  # prevent unbounded memory growth
+    CLEANUP_INTERVAL_SECONDS = 30  # #103: run expired-sweep at least this often
 
     def __init__(self, max_requests: int = 60, window_seconds: int = 60):
         self.max_requests = max_requests
         self.window = window_seconds
         self.requests: dict[str, list[float]] = defaultdict(list)
         self._lock = threading.Lock()
+        self._last_cleanup: float = 0.0
 
     def _cleanup(self) -> None:
         """Remove expired entries; evict LRU entries when MAX_KEYS is exceeded."""
@@ -60,6 +62,7 @@ class RateLimiter:
             )
             for k in sorted_keys[: len(self.requests) - self.MAX_KEYS]:
                 del self.requests[k]
+        self._last_cleanup = now
 
     def is_allowed(self, client_id: str) -> bool:
         now = time.time()
@@ -70,8 +73,15 @@ class RateLimiter:
             if len(self.requests[client_id]) >= self.max_requests:
                 return False
             self.requests[client_id].append(now)
-            # Periodic cleanup to prevent unbounded memory growth
-            if len(self.requests) > self.MAX_KEYS:
+            # #103: two-track cleanup to bound memory even when key count
+            # stays well below MAX_KEYS.
+            #  (a) Hard cap: when over MAX_KEYS we must evict now.
+            #  (b) Soft cap: at least every CLEANUP_INTERVAL_SECONDS run a
+            #      lightweight expired-sweep so stale keys don't accrete.
+            if (
+                len(self.requests) > self.MAX_KEYS
+                or now - self._last_cleanup >= self.CLEANUP_INTERVAL_SECONDS
+            ):
                 self._cleanup()
             return True
 

--- a/tests/test_ratelimiter_cleanup.py
+++ b/tests/test_ratelimiter_cleanup.py
@@ -1,0 +1,89 @@
+"""Regression: RateLimiter periodic expired-sweep (#103).
+
+Before #103, `_cleanup()` only fired when `len(self.requests) > MAX_KEYS`
+(10,000). With fewer keys, expired entries accumulated forever in the
+defaultdict — a slow-but-real memory leak on long-running servers with
+moderate unique-IP traffic.
+
+Fix: add a `CLEANUP_INTERVAL_SECONDS` bound so the sweep runs on a
+time-based schedule regardless of total key count.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from faultray.api.server import RateLimiter
+
+
+def test_expired_keys_are_swept_below_max_keys_after_interval(monkeypatch):
+    """Stale keys get evicted once CLEANUP_INTERVAL_SECONDS elapses, even
+    when the total key count is far below MAX_KEYS."""
+    # Shrink interval and window so the test runs quickly.
+    rl = RateLimiter(max_requests=10, window_seconds=1)
+    rl.CLEANUP_INTERVAL_SECONDS = 0  # cleanup every call for determinism
+
+    # Seed 100 unique "clients" — well below MAX_KEYS=10,000.
+    for i in range(100):
+        assert rl.is_allowed(f"client-{i}") is True
+
+    assert len(rl.requests) == 100
+
+    # Wait past the window so every entry is expired.
+    time.sleep(1.1)
+
+    # A single call from one new client should trigger _cleanup() because
+    # CLEANUP_INTERVAL_SECONDS=0 → always run. All 100 stale keys must be
+    # evicted; only the new caller's one key remains.
+    rl.is_allowed("fresh-client")
+
+    assert "fresh-client" in rl.requests
+    assert len(rl.requests) == 1, (
+        f"expected only 1 live key after expired sweep, saw {len(rl.requests)}: "
+        f"{list(rl.requests)[:10]}..."
+    )
+
+
+def test_interval_default_bounded_to_reasonable_value():
+    """CLEANUP_INTERVAL_SECONDS must be set to a positive finite number
+    so the sweep runs at least occasionally; guards against accidental
+    regressions that would disable the soft cap."""
+    assert 1 <= RateLimiter.CLEANUP_INTERVAL_SECONDS <= 300
+
+
+def test_cleanup_preserves_active_client_requests(monkeypatch):
+    """A client who just made requests must not be swept out by the
+    periodic sweep."""
+    rl = RateLimiter(max_requests=10, window_seconds=60)
+    rl.CLEANUP_INTERVAL_SECONDS = 0  # always cleanup
+
+    # Active client — all timestamps are fresh.
+    for _ in range(3):
+        rl.is_allowed("active")
+
+    # Stale client — fabricate an expired timestamp directly.
+    rl.requests["stale"].append(time.time() - 9999)
+
+    # Trigger cleanup via a new call from any client.
+    rl.is_allowed("active")
+
+    assert "active" in rl.requests
+    assert "stale" not in rl.requests
+
+
+def test_hard_cap_still_enforced_when_over_max_keys(monkeypatch):
+    """The MAX_KEYS hard-cap path must still evict down to MAX_KEYS even
+    when nothing is expired yet."""
+    rl = RateLimiter(max_requests=10, window_seconds=60)
+    rl.MAX_KEYS = 5
+    rl.CLEANUP_INTERVAL_SECONDS = 9999  # disable time-based path
+
+    for i in range(10):
+        rl.is_allowed(f"k{i}")
+
+    # After the 10th call, _cleanup() should have run (over MAX_KEYS).
+    assert len(rl.requests) <= rl.MAX_KEYS, (
+        f"hard cap failed: len={len(rl.requests)} but MAX_KEYS={rl.MAX_KEYS}"
+    )

--- a/tests/test_ratelimiter_cleanup.py
+++ b/tests/test_ratelimiter_cleanup.py
@@ -87,3 +87,19 @@ def test_hard_cap_still_enforced_when_over_max_keys(monkeypatch):
     assert len(rl.requests) <= rl.MAX_KEYS, (
         f"hard cap failed: len={len(rl.requests)} but MAX_KEYS={rl.MAX_KEYS}"
     )
+
+
+def test_default_interval_is_30_seconds():
+    """Self-review follow-up: verify the real default (not an override)."""
+    assert RateLimiter.CLEANUP_INTERVAL_SECONDS == 30
+
+
+def test_no_sweep_under_interval_documents_limitation():
+    """Honest limitation test: with the 30s default, expired entries
+    added within the window stay in the dict until the next call that
+    crosses the interval. Documented trade-off, not a bug."""
+    rl = RateLimiter(max_requests=10, window_seconds=1)
+    rl.is_allowed("seed")                        # sets _last_cleanup = now
+    rl.requests["stale"].append(time.time() - 9999)  # inject expired entry
+    rl.is_allowed("fresh")                       # <1s later → no sweep
+    assert "stale" in rl.requests


### PR DESCRIPTION
## Summary
`_cleanup()` が `len(self.requests) > MAX_KEYS` (10,000) のときしか呼ばれず、key 数が MAX_KEYS 未満の環境では expired エントリが `defaultdict` に残留し続ける **緩やかなメモリリーク** (moderate unique-IP traffic の長時間プロセスで兆候) を解消。

## 変更
- `RateLimiter.CLEANUP_INTERVAL_SECONDS = 30` を新設
- `_last_cleanup` timestamp を保持、`_cleanup()` 末尾で更新
- `is_allowed()` の cleanup 発火条件を **hard cap OR soft cap** の OR に拡張:
  - hard: `len(self.requests) > MAX_KEYS` (既存、即 evict)
  - soft: `now - self._last_cleanup >= CLEANUP_INTERVAL_SECONDS` (新規、定期 sweep)

## Regression lock
`tests/test_ratelimiter_cleanup.py` (4 ケース):
1. 100 key (<< MAX_KEYS) を expire させ 1 回 call で 1 key まで削減
2. CLEANUP_INTERVAL_SECONDS が 1..300 秒の reasonable 範囲
3. active client が誤って evict されない
4. MAX_KEYS 超過時の hard cap が引き続き機能

ローカル: 4/4 pass。

Closes #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray/pull/120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
