### PR TITLE
docs(#83): agent_config / llm_config / tool_config / orchestrator_config guide + examples

### DIFF
--- a/docs/guides/agent-topology.md
+++ b/docs/guides/agent-topology.md
@@ -1,0 +1,139 @@
+# AI Agent Topology (#83)
+
+FaultRay v11+ models AI agents as first-class components alongside
+infrastructure. Four optional YAML config groups describe agent behavior:
+
+| Group | Purpose | Flattened into |
+|---|---|---|
+| `agent_config` | Agent-level behavior (loop limits, memory, tools) | `component.parameters` |
+| `llm_config` | LLM choice + rate limits + fallback | `component.parameters` |
+| `tool_config` | External tool allow-list + permissions | `component.parameters` |
+| `orchestrator_config` | Multi-agent orchestration (supervisor, voting) | `component.parameters` |
+
+All four groups are **optional** — omit what you don't need. Keys get
+flattened into `component.parameters` (see
+`src/faultray/model/loader.py:214-224`) so downstream simulator engines
+(adoption, monitor, scenarios) see a unified parameter bag.
+
+## Minimal example
+
+```yaml
+# examples/agent-topology-minimal.yaml
+schema_version: "4.0"
+components:
+  - id: sre_bot
+    name: SRE Copilot
+    type: ai_agent
+    host: agent-sre.internal
+    port: 443
+
+    agent_config:
+      max_loop_iterations: 5
+      memory_backend: redis
+      timeout_seconds: 30
+
+    llm_config:
+      provider: anthropic
+      model: claude-sonnet-4
+      max_tokens: 4000
+      rate_limit_rpm: 60
+      fallback_provider: openai
+      fallback_model: gpt-4.1
+
+    tool_config:
+      allowed_tools:
+        - kubectl.read
+        - prometheus.query
+      permission_mode: least_privilege
+
+  - id: kubernetes
+    name: Kubernetes API
+    type: container_orchestrator
+    host: kubeapi.internal
+    port: 6443
+
+dependencies:
+  - source: sre_bot
+    target: kubernetes
+    type: requires
+```
+
+## Advanced: multi-agent orchestrator
+
+```yaml
+# examples/agent-topology-advanced.yaml
+schema_version: "4.0"
+components:
+  - id: supervisor
+    name: Incident Supervisor
+    type: ai_agent
+
+    agent_config:
+      role: supervisor
+      max_loop_iterations: 3
+
+    orchestrator_config:
+      strategy: majority_vote
+      workers: [triage_bot, remediation_bot, audit_bot]
+      voting_threshold: 0.67
+      timeout_seconds: 60
+
+  - id: triage_bot
+    name: Triage Agent
+    type: ai_agent
+    agent_config: { role: worker, specialty: log_analysis }
+    llm_config: { provider: anthropic, model: claude-haiku-4-5 }
+
+  - id: remediation_bot
+    name: Remediation Agent
+    type: ai_agent
+    agent_config: { role: worker, specialty: infra_action }
+    llm_config: { provider: anthropic, model: claude-sonnet-4-6 }
+    tool_config:
+      allowed_tools: [kubectl.patch, pagerduty.resolve]
+      permission_mode: require_approval
+
+  - id: audit_bot
+    name: Audit Agent
+    type: ai_agent
+    agent_config: { role: worker, specialty: compliance_check }
+    llm_config: { provider: openai, model: gpt-4.1 }
+
+dependencies:
+  - { source: supervisor, target: triage_bot, type: requires }
+  - { source: supervisor, target: remediation_bot, type: requires }
+  - { source: supervisor, target: audit_bot, type: requires }
+```
+
+## Key → engine mapping
+
+These keys are what the simulator engines look for after flattening:
+
+| Parameter key (flattened) | Consumer engine |
+|---|---|
+| `max_loop_iterations` | `AdoptionEngine` (loop-risk heuristic) |
+| `memory_backend` | `AdoptionEngine` (state-loss blast-radius) |
+| `timeout_seconds` | `AgentMonitorEngine` (SLO alerts) |
+| `provider` / `model` | `AdoptionEngine` (rate-limit cascade) |
+| `rate_limit_rpm` | `AdoptionEngine` + scenario generator |
+| `fallback_provider` / `fallback_model` | resilience credit in score |
+| `allowed_tools` | `AgentScenarios` (blast radius bound) |
+| `permission_mode` | `AgentScenarios` + supply-chain engine |
+| `strategy` (orchestrator) | multi-agent cascade scenario |
+| `voting_threshold` | orchestrator quorum scenario |
+
+Unknown keys are passed through — forward-compatible for new engines.
+
+## Validation
+
+`faultray load <file>.yaml` prints a warning line if a required key is
+missing for an `ai_agent`-typed component. `faultray simulate --engine
+agent` refuses to run if no `agent_config` or `llm_config` is present
+on any `ai_agent` node.
+
+## Related
+
+- [Minimal example](../../examples/agent-topology-minimal.yaml)
+- [Advanced example](../../examples/agent-topology-advanced.yaml)
+- Loader source: `src/faultray/model/loader.py:214-224` (flattening)
+- CHANGELOG v11.0.0 entry: introduced the four config groups

--- a/examples/agent-topology-advanced.yaml
+++ b/examples/agent-topology-advanced.yaml
@@ -1,0 +1,73 @@
+# Multi-agent orchestrator topology — 1 supervisor, 3 workers.
+# Demonstrates orchestrator_config (majority-vote) + per-worker
+# llm_config / tool_config. See docs/guides/agent-topology.md (#83).
+schema_version: "4.0"
+
+components:
+  - id: supervisor
+    name: Incident Supervisor
+    type: ai_agent
+    host: agent-supervisor.internal
+    port: 443
+    replicas: 1
+    region: { region: us-east-1 }
+
+    agent_config:
+      role: supervisor
+      max_loop_iterations: 3
+      timeout_seconds: 120
+
+    orchestrator_config:
+      strategy: majority_vote
+      workers: [triage_bot, remediation_bot, audit_bot]
+      voting_threshold: 0.67
+      timeout_seconds: 60
+
+  - id: triage_bot
+    name: Triage Agent
+    type: ai_agent
+    host: agent-triage.internal
+    port: 443
+    agent_config:
+      role: worker
+      specialty: log_analysis
+    llm_config:
+      provider: anthropic
+      model: claude-haiku-4-5
+      rate_limit_rpm: 120
+
+  - id: remediation_bot
+    name: Remediation Agent
+    type: ai_agent
+    host: agent-remediation.internal
+    port: 443
+    agent_config:
+      role: worker
+      specialty: infra_action
+    llm_config:
+      provider: anthropic
+      model: claude-sonnet-4-6
+      rate_limit_rpm: 30
+    tool_config:
+      allowed_tools:
+        - kubectl.patch
+        - pagerduty.resolve
+      permission_mode: require_approval
+
+  - id: audit_bot
+    name: Audit Agent
+    type: ai_agent
+    host: agent-audit.internal
+    port: 443
+    agent_config:
+      role: worker
+      specialty: compliance_check
+    llm_config:
+      provider: openai
+      model: gpt-4.1
+      rate_limit_rpm: 60
+
+dependencies:
+  - { source: supervisor, target: triage_bot, type: requires }
+  - { source: supervisor, target: remediation_bot, type: requires }
+  - { source: supervisor, target: audit_bot, type: requires }

--- a/examples/agent-topology-minimal.yaml
+++ b/examples/agent-topology-minimal.yaml
@@ -1,0 +1,44 @@
+# Minimal AI agent topology — 1 agent + 1 dependency.
+# See docs/guides/agent-topology.md (#83) for all 4 config groups.
+schema_version: "4.0"
+
+components:
+  - id: sre_bot
+    name: SRE Copilot
+    type: ai_agent
+    host: agent-sre.internal
+    port: 443
+    replicas: 1
+    region: { region: us-east-1 }
+
+    agent_config:
+      max_loop_iterations: 5
+      memory_backend: redis
+      timeout_seconds: 30
+
+    llm_config:
+      provider: anthropic
+      model: claude-sonnet-4
+      max_tokens: 4000
+      rate_limit_rpm: 60
+      fallback_provider: openai
+      fallback_model: gpt-4.1
+
+    tool_config:
+      allowed_tools:
+        - kubectl.read
+        - prometheus.query
+      permission_mode: least_privilege
+
+  - id: kubernetes
+    name: Kubernetes API
+    type: external_api
+    host: kubeapi.internal
+    port: 6443
+    replicas: 3
+    region: { region: us-east-1 }
+
+dependencies:
+  - source: sre_bot
+    target: kubernetes
+    type: requires

--- a/tests/test_agent_topology_docs.py
+++ b/tests/test_agent_topology_docs.py
@@ -1,0 +1,48 @@
+"""Regression: agent_config / llm_config / tool_config / orchestrator_config
+are documented with working examples (#83)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_agent_topology_guide_exists():
+    p = _ROOT / "docs" / "guides" / "agent-topology.md"
+    assert p.exists(), "docs/guides/agent-topology.md missing (#83)"
+    text = p.read_text(encoding="utf-8")
+    for key in ("agent_config", "llm_config", "tool_config", "orchestrator_config"):
+        assert key in text, f"guide must document '{key}' (#83)"
+
+
+def test_minimal_example_valid_yaml_and_has_agent_config():
+    p = _ROOT / "examples" / "agent-topology-minimal.yaml"
+    assert p.exists()
+    data = yaml.safe_load(p.read_text(encoding="utf-8"))
+    assert data["schema_version"] == "4.0"
+    agent = next(c for c in data["components"] if c["type"] == "ai_agent")
+    assert "agent_config" in agent
+    assert "llm_config" in agent
+
+
+def test_advanced_example_exercises_orchestrator_config():
+    p = _ROOT / "examples" / "agent-topology-advanced.yaml"
+    assert p.exists()
+    data = yaml.safe_load(p.read_text(encoding="utf-8"))
+    supervisor = next(c for c in data["components"] if c["id"] == "supervisor")
+    assert "orchestrator_config" in supervisor
+    assert supervisor["orchestrator_config"]["strategy"] == "majority_vote"
+    assert len(supervisor["orchestrator_config"]["workers"]) == 3
+
+
+def test_examples_load_via_faultray_loader():
+    """End-to-end: loader flattens configs into parameters without error."""
+    from faultray.model.loader import load_yaml
+
+    for fname in ("agent-topology-minimal.yaml", "agent-topology-advanced.yaml"):
+        p = _ROOT / "examples" / fname
+        graph = load_yaml(p)
+        assert graph.components, f"{fname} produced an empty graph"


### PR DESCRIPTION
CHANGELOG v11.0.0 が announce した 4 YAML syntax に対して docs/examples が 0 件だった問題を解消。

- docs/guides/agent-topology.md: 4 group の用途表 + key→engine mapping
- examples/agent-topology-minimal.yaml: 最小 1 agent
- examples/agent-topology-advanced.yaml: supervisor + 3 worker 多数決
- tests/test_agent_topology_docs.py: doc 存在 + YAML valid + loader e2e (4 pass)

Closes #83.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray/pull/121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
