### PR TITLE
feat(cli): CLI deprecation warning mechanism (#86)

### DIFF
--- a/src/faultray/cli/deprecation.py
+++ b/src/faultray/cli/deprecation.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2025-2026 Yutaro Maeda. All rights reserved.
+# Licensed under the Apache License 2.0. See LICENSE file for details.
+
+"""CLI deprecation warning mechanism (#86).
+
+Provides a small helper so CLI commands / options can be marked
+deprecated and a visible warning surfaces on every call until the
+planned removal version.
+
+Usage::
+
+    from faultray.cli.deprecation import deprecated_command
+
+    @app.command()
+    @deprecated_command(
+        reason="Use `faultray financial run` instead",
+        removed_in="12.0.0",
+    )
+    def old_financial():
+        ...
+
+Suppress with ``FAULTRAY_SUPPRESS_DEPRECATION=1`` in scripts.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+import sys
+import warnings
+from collections.abc import Callable
+from typing import Any
+
+
+class FaultRayDeprecationWarning(DeprecationWarning):
+    """Dedicated warning class so users can filter FaultRay-only signals."""
+
+
+def deprecated_command(
+    *, reason: str, removed_in: str, name: str | None = None
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorate a CLI command function to emit a deprecation warning.
+
+    Args:
+        reason: Short rationale + replacement path ("Use ``foo`` instead").
+        removed_in: Target removal version (SemVer). Informational only —
+            we do not auto-disable at this version; that is a manual op.
+        name: Override the command label in the warning message. Defaults
+            to the decorated function's ``__name__``.
+    """
+    def _wrap(fn: Callable[..., Any]) -> Callable[..., Any]:
+        label = name or fn.__name__
+
+        @functools.wraps(fn)
+        def _wrapped(*args: Any, **kwargs: Any) -> Any:
+            if not _is_deprecation_suppressed():
+                _emit_warning(
+                    f"CLI command '{label}' is deprecated and will be "
+                    f"removed in v{removed_in}. {reason}"
+                )
+            return fn(*args, **kwargs)
+
+        # Attach metadata for CHANGELOG / help generators.
+        _wrapped.__faultray_deprecated__ = {       # type: ignore[attr-defined]
+            "reason": reason,
+            "removed_in": removed_in,
+            "name": label,
+        }
+        return _wrapped
+
+    return _wrap
+
+
+def warn_deprecated_option(
+    option_name: str, *, reason: str, removed_in: str
+) -> None:
+    """Imperative form for deprecating an option (when the decorator does
+    not fit, e.g. the option is parsed conditionally).
+
+    Usage::
+
+        if args.old_flag is not None:
+            warn_deprecated_option(
+                "--old-flag",
+                reason="Use --new-flag instead",
+                removed_in="12.0.0",
+            )
+    """
+    if _is_deprecation_suppressed():
+        return
+    _emit_warning(
+        f"CLI option '{option_name}' is deprecated and will be removed in "
+        f"v{removed_in}. {reason}"
+    )
+
+
+def _is_deprecation_suppressed() -> bool:
+    return os.environ.get("FAULTRAY_SUPPRESS_DEPRECATION", "").lower() in (
+        "1", "true", "yes"
+    )
+
+
+def _emit_warning(message: str) -> None:
+    # stderr so it does not pollute JSON output captured from stdout.
+    print(f"\x1b[33m[DEPRECATION]\x1b[0m {message}", file=sys.stderr)
+    warnings.warn(message, FaultRayDeprecationWarning, stacklevel=3)

--- a/tests/test_cli_deprecation.py
+++ b/tests/test_cli_deprecation.py
@@ -1,0 +1,78 @@
+"""Regression: CLI deprecation warning mechanism (#86)."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from faultray.cli.deprecation import (
+    FaultRayDeprecationWarning,
+    deprecated_command,
+    warn_deprecated_option,
+)
+
+
+def test_deprecated_command_emits_warning_on_call(capsys):
+    @deprecated_command(reason="Use `foo` instead", removed_in="12.0.0")
+    def _cmd(x):
+        return x * 2
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always", FaultRayDeprecationWarning)
+        result = _cmd(3)
+
+    assert result == 6
+    err = capsys.readouterr().err
+    assert "[DEPRECATION]" in err
+    assert "v12.0.0" in err
+    assert "Use `foo` instead" in err
+
+    assert any(issubclass(rec.category, FaultRayDeprecationWarning) for rec in w)
+
+
+def test_deprecation_metadata_attached():
+    @deprecated_command(reason="Use `new` instead", removed_in="12.0.0")
+    def _cmd():
+        pass
+
+    meta = getattr(_cmd, "__faultray_deprecated__", None)
+    assert meta is not None
+    assert meta["removed_in"] == "12.0.0"
+    assert meta["reason"].startswith("Use")
+
+
+def test_suppress_env_silences_warning(capsys, monkeypatch):
+    monkeypatch.setenv("FAULTRAY_SUPPRESS_DEPRECATION", "1")
+
+    @deprecated_command(reason="gone", removed_in="12.0.0")
+    def _cmd():
+        return 7
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always", FaultRayDeprecationWarning)
+        _cmd()
+
+    err = capsys.readouterr().err
+    assert "[DEPRECATION]" not in err
+    assert not any(issubclass(rec.category, FaultRayDeprecationWarning) for rec in w)
+
+
+def test_warn_deprecated_option_imperative(capsys, monkeypatch):
+    monkeypatch.delenv("FAULTRAY_SUPPRESS_DEPRECATION", raising=False)
+    warn_deprecated_option(
+        "--old-flag", reason="Use --new-flag", removed_in="12.0.0"
+    )
+    err = capsys.readouterr().err
+    assert "[DEPRECATION]" in err
+    assert "--old-flag" in err
+
+
+def test_custom_name_override(capsys):
+    @deprecated_command(reason="gone", removed_in="12.0.0", name="legacy-foo")
+    def some_internal_function():
+        pass
+
+    some_internal_function()
+    err = capsys.readouterr().err
+    assert "legacy-foo" in err


### PR DESCRIPTION
CLI 側に breaking change 予告の共通機構が無かったのを追加。

- `src/faultray/cli/deprecation.py`: @deprecated_command decorator + warn_deprecated_option 関数
- FAULTRAY_SUPPRESS_DEPRECATION=1 で silencing
- FaultRayDeprecationWarning で warning filter 可能
- stderr に黄色 [DEPRECATION] prefix、JSON 出力汚染なし
- 5 regression test (emit / metadata / suppress / imperative / custom name)

Closes #86.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray/pull/122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
