### PR TITLE
chore(ci): bump softprops/action-gh-release v3, attest-build-provenance v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
         # Only runs when a Release event fires (not for raw tag push), so
         # the softprops action receives the existing release to upload to.
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             dist/*.whl
@@ -170,7 +170,7 @@ jobs:
 
       - name: Attach Docker SBOM to GitHub Release
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             faultray-${{ needs.extract-version.outputs.version }}-docker.cdx.json


### PR DESCRIPTION
## Summary
- `softprops/action-gh-release` v2 → v3
- `actions/attest-build-provenance` v2 → v4

## Why
Equivalent to dependabot PRs #124/#125 that were closed because the OAuth token used for CLI merge lacks the GitHub `workflow` scope.

## Verified breaking changes (web-fetched 2026-04-30)
- `softprops/action-gh-release` v3: Node 20 → Node 24 runtime only. GitHub-hosted runners (v2.327.1+) compatible
- `attest-build-provenance` v4: now a thin wrapper over `actions/attest`. Behavior unchanged for our usage (release workflow signing artifacts)

## Test plan
- [ ] CI passes on this PR
- [ ] Next release tag triggers release.yml without regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mattyopon/faultray/pull/127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
