### PR TITLE
fix(plugins): close discovery+plugin-dir RCE (#149, #150)

### DIFF
--- a/src/faultray/cli/simulate.py
+++ b/src/faultray/cli/simulate.py
@@ -191,6 +191,15 @@ def simulate(
     dynamic: bool = typer.Option(False, "--dynamic", "-d", help="Run dynamic time-stepped simulation"),
     analyze_flag: bool = typer.Option(False, "--analyze", "-a", help="Run AI analysis after simulation"),
     plugins_dir: Path | None = typer.Option(None, "--plugins-dir", help="Directory of plugin .py files to load"),
+    trust_plugins_dir: bool = typer.Option(
+        False,
+        "--trust-plugins-dir",
+        help=(
+            "Explicitly opt in to executing plugin code from --plugins-dir. The directory "
+            "must also be listed in FAULTRAY_PLUGIN_TRUSTED_DIRS (os.pathsep separated). "
+            "Without both gates, plugin loading is refused (see #150)."
+        ),
+    ),
     slack_webhook: str | None = typer.Option(None, "--slack-webhook", help="Slack webhook URL for notifications"),
     pagerduty_key: str | None = typer.Option(None, "--pagerduty-key", help="PagerDuty routing key for critical alerts"),
     max_scenarios: int = typer.Option(0, "--max-scenarios", help="Max scenarios to test (0 = engine default)"),
@@ -243,12 +252,20 @@ def simulate(
         console.print("Run [cyan]faultray scan[/] first to create a model.")
         raise typer.Exit(1)
 
-    # Load plugins if a directory is specified
+    # Load plugins if a directory is specified.
+    # Security (#150): require explicit --trust-plugins-dir AND
+    # FAULTRAY_PLUGIN_TRUSTED_DIRS membership; otherwise the registry refuses.
     if plugins_dir is not None:
         from faultray.plugins.registry import PluginRegistry
 
-        console.print(f"[cyan]Loading plugins from {plugins_dir}...[/]")
-        PluginRegistry.load_plugins_from_dir(plugins_dir)
+        if not trust_plugins_dir:
+            console.print(
+                f"[yellow]Skipping plugins in {plugins_dir}: pass --trust-plugins-dir "
+                f"and add the directory to FAULTRAY_PLUGIN_TRUSTED_DIRS to load.[/]"
+            )
+        else:
+            console.print(f"[cyan]Loading plugins from {plugins_dir}...[/]")
+            PluginRegistry.load_plugins_from_dir(plugins_dir, trusted=True)
 
     if json_output:
         # Suppress logging to stdout so JSON output is parseable

--- a/src/faultray/plugins/plugin_manager.py
+++ b/src/faultray/plugins/plugin_manager.py
@@ -20,6 +20,7 @@ Plugin discovery:
 
 from __future__ import annotations
 
+import ast
 import importlib
 import importlib.util
 import logging
@@ -484,38 +485,63 @@ class PluginManager:
 
     @staticmethod
     def _read_metadata_from_file(py_file: Path) -> PluginMetadata | None:
-        """Extract ``PLUGIN_METADATA`` dict from a Python source file."""
+        """Extract ``PLUGIN_METADATA`` dict statically via AST (no module execution).
+
+        Security (#149): discovery で ``exec_module`` を呼ぶと plugin dir に置か
+        れた任意の Python が import 時に走り、書き込み権限を取った攻撃者から
+        RCE できる。ここでは module 化せず ``ast.literal_eval`` で literal の
+        ``PLUGIN_METADATA = {...}`` だけを取り出す。実際の import は ``load()``
+        の trust 経路でのみ行う。
+        """
         try:
-            spec = importlib.util.spec_from_file_location(py_file.stem, py_file)
-            if spec is None or spec.loader is None:
-                return None
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)  # type: ignore[union-attr]
-
-            raw = getattr(module, "PLUGIN_METADATA", None)
-            if not isinstance(raw, dict):
-                return None
-
-            try:
-                ptype = PluginType(raw.get("type", "scenario_generator"))
-            except ValueError:
-                ptype = PluginType.SCENARIO_GENERATOR
-
-            return PluginMetadata(
-                name=raw.get("name", py_file.stem),
-                version=raw.get("version", "0.0.0"),
-                author=raw.get("author", "unknown"),
-                description=raw.get("description", ""),
-                plugin_type=ptype,
-                entry_point=str(py_file),
-                dependencies=raw.get("dependencies", []),
-                config_schema=raw.get("config_schema"),
-                enabled=raw.get("enabled", True),
-                source="local",
-            )
-        except Exception:
-            logger.debug("Failed to read metadata from %s", py_file, exc_info=True)
+            source = py_file.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=str(py_file))
+        except (OSError, UnicodeDecodeError, SyntaxError):
+            logger.debug("Failed to read/parse %s", py_file, exc_info=True)
             return None
+
+        raw: dict[str, Any] | None = None
+        for node in tree.body:
+            targets: list[ast.expr]
+            if isinstance(node, ast.Assign):
+                targets = list(node.targets)
+                value = node.value
+            elif isinstance(node, ast.AnnAssign) and node.value is not None:
+                targets = [node.target]
+                value = node.value
+            else:
+                continue
+            if not any(isinstance(t, ast.Name) and t.id == "PLUGIN_METADATA" for t in targets):
+                continue
+            try:
+                evaluated = ast.literal_eval(value)
+            except (ValueError, SyntaxError):
+                logger.debug("PLUGIN_METADATA in %s is not a literal", py_file)
+                return None
+            if isinstance(evaluated, dict):
+                raw = evaluated
+            break
+
+        if raw is None:
+            return None
+
+        try:
+            ptype = PluginType(raw.get("type", "scenario_generator"))
+        except ValueError:
+            ptype = PluginType.SCENARIO_GENERATOR
+
+        return PluginMetadata(
+            name=raw.get("name", py_file.stem),
+            version=raw.get("version", "0.0.0"),
+            author=raw.get("author", "unknown"),
+            description=raw.get("description", ""),
+            plugin_type=ptype,
+            entry_point=str(py_file),
+            dependencies=raw.get("dependencies", []),
+            config_schema=raw.get("config_schema"),
+            enabled=raw.get("enabled", True),
+            source="local",
+        )
 
     # ---- Loading -----------------------------------------------------------
 

--- a/src/faultray/plugins/registry.py
+++ b/src/faultray/plugins/registry.py
@@ -4,6 +4,7 @@
 """Plugin registry for custom scenarios and analyzers."""
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 import importlib.util
@@ -82,10 +83,33 @@ class PluginRegistry:
         cls._discovery_plugins.append(plugin)
 
     @classmethod
-    def load_plugins_from_dir(cls, plugin_dir: Path):
-        """Load all .py files from a directory as plugins."""
+    def load_plugins_from_dir(cls, plugin_dir: Path, *, trusted: bool = False) -> None:
+        """Load all .py files from a directory as plugins.
+
+        Security (#150): ``exec_module`` で任意 Python を実行するため、untrusted
+        な directory を直接食わせると RCE。読み込みには 2 ガードを要求する:
+
+        1. 呼び出し側が ``trusted=True`` を **明示** で指定する。
+        2. 解決済みパスが env ``FAULTRAY_PLUGIN_TRUSTED_DIRS`` (os.pathsep 区切り)
+           に含まれる either as the dir itself or a parent.
+
+        どちらか一方でも欠けると fail-closed で warning ログを出して return する。
+        CLI からは ``--trust-plugins-dir`` で明示 opt-in する。
+        """
         if not plugin_dir.exists():
             return
+
+        resolved = plugin_dir.resolve()
+
+        if not _plugin_dir_is_trusted(resolved, opt_in=trusted):
+            logger.warning(
+                "Refusing to load plugins from %s: trust gate not satisfied. "
+                "Pass trusted=True AND add the directory (or a parent) to "
+                "FAULTRAY_PLUGIN_TRUSTED_DIRS to opt in.",
+                resolved,
+            )
+            return
+
         for py_file in sorted(plugin_dir.glob("*.py")):
             if py_file.name.startswith("_"):
                 continue
@@ -128,3 +152,35 @@ class PluginRegistry:
         cls._engine_plugins.clear()
         cls._reporter_plugins.clear()
         cls._discovery_plugins.clear()
+
+
+_TRUSTED_DIRS_ENV = "FAULTRAY_PLUGIN_TRUSTED_DIRS"
+
+
+def _plugin_dir_is_trusted(resolved: Path, *, opt_in: bool) -> bool:
+    """Return True only when caller opted in *and* env allowlist matches.
+
+    Both gates must agree so that a single-point misconfiguration (env set but
+    caller forgot the flag, or vice versa) fails closed.
+    """
+    if not opt_in:
+        return False
+    raw = os.environ.get(_TRUSTED_DIRS_ENV, "")
+    if not raw.strip():
+        return False
+    for entry in raw.split(os.pathsep):
+        candidate = entry.strip()
+        if not candidate:
+            continue
+        try:
+            trusted = Path(candidate).expanduser().resolve()
+        except OSError:
+            continue
+        if resolved == trusted:
+            return True
+        try:
+            resolved.relative_to(trusted)
+            return True
+        except ValueError:
+            continue
+    return False

--- a/tests/test_final_coverage.py
+++ b/tests/test_final_coverage.py
@@ -701,7 +701,7 @@ class TestPluginLoadingException:
         bad_plugin.write_text("raise RuntimeError('intentional error')\n")
 
         # Should not raise; should log a warning
-        PluginRegistry.load_plugins_from_dir(tmp_path)
+        PluginRegistry.load_plugins_from_dir(tmp_path, trusted=True)
 
         # No plugins should have been registered
         assert len(PluginRegistry.get_scenario_plugins()) == 0
@@ -717,7 +717,7 @@ class TestPluginLoadingException:
         bad_plugin = tmp_path / "syntax_error.py"
         bad_plugin.write_text("def broken(\n")
 
-        PluginRegistry.load_plugins_from_dir(tmp_path)
+        PluginRegistry.load_plugins_from_dir(tmp_path, trusted=True)
 
         assert len(PluginRegistry.get_scenario_plugins()) == 0
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -22,6 +22,16 @@ def _clean_registry():
     PluginRegistry.clear()
 
 
+@pytest.fixture(autouse=True)
+def _trust_tmp_plugin_dirs(tmp_path, monkeypatch):
+    """#150: tests routinely load plugins from tmp_path; whitelist it.
+
+    Tests must still pass ``trusted=True`` explicitly to opt in — this fixture
+    only handles the env half of the trust gate.
+    """
+    monkeypatch.setenv("FAULTRAY_PLUGIN_TRUSTED_DIRS", str(tmp_path))
+
+
 class _DummyScenarioPlugin:
     """A minimal scenario plugin for testing."""
 
@@ -100,19 +110,19 @@ class TestPluginRegistry:
             """)
         )
 
-        PluginRegistry.load_plugins_from_dir(tmp_path)
+        PluginRegistry.load_plugins_from_dir(tmp_path, trusted=True)
         assert len(PluginRegistry.get_scenario_plugins()) == 1
         assert PluginRegistry.get_scenario_plugins()[0].name == "my-plugin"
 
     def test_load_plugins_skips_underscore_files(self, tmp_path: Path):
         """Files starting with _ should be skipped."""
         (tmp_path / "_internal.py").write_text("raise RuntimeError('should not load')")
-        PluginRegistry.load_plugins_from_dir(tmp_path)
+        PluginRegistry.load_plugins_from_dir(tmp_path, trusted=True)
         assert PluginRegistry.get_scenario_plugins() == []
 
     def test_load_plugins_nonexistent_dir(self, tmp_path: Path):
         """Loading from a non-existent directory should be a no-op."""
-        PluginRegistry.load_plugins_from_dir(tmp_path / "nonexistent")
+        PluginRegistry.load_plugins_from_dir(tmp_path / "nonexistent", trusted=True)
         assert PluginRegistry.get_scenario_plugins() == []
 
 
@@ -296,7 +306,7 @@ class TestLoadPluginsFromDirExtended:
         """Plugin files with syntax errors should be skipped gracefully."""
         bad_file = tmp_path / "bad_plugin.py"
         bad_file.write_text("def register(registry):\n    raise RuntimeError('boom')\n")
-        PluginRegistry.load_plugins_from_dir(tmp_path)
+        PluginRegistry.load_plugins_from_dir(tmp_path, trusted=True)
         # Should not crash, and no plugins should be registered
         assert len(PluginRegistry.get_scenario_plugins()) == 0
 
@@ -304,7 +314,7 @@ class TestLoadPluginsFromDirExtended:
         """Plugin files without register() should be loaded but not register anything."""
         plugin_file = tmp_path / "no_register.py"
         plugin_file.write_text("x = 42\n")
-        PluginRegistry.load_plugins_from_dir(tmp_path)
+        PluginRegistry.load_plugins_from_dir(tmp_path, trusted=True)
         assert len(PluginRegistry.get_scenario_plugins()) == 0
 
     def test_load_multiple_plugins(self, tmp_path: Path):
@@ -321,5 +331,130 @@ class TestLoadPluginsFromDirExtended:
                 def register(registry):
                     registry.register_scenario(Plugin{i}())
             """))
-        PluginRegistry.load_plugins_from_dir(tmp_path)
+        PluginRegistry.load_plugins_from_dir(tmp_path, trusted=True)
         assert len(PluginRegistry.get_scenario_plugins()) == 3
+
+
+class TestLoadPluginsTrustGate:
+    """#150: load_plugins_from_dir must refuse untrusted directories."""
+
+    def test_refuses_without_opt_in_even_with_env(self, tmp_path: Path, caplog):
+        """Caller forgot ``trusted=True`` → refused even if env allows."""
+        canary = tmp_path / "boom.py"
+        canary.write_text(textwrap.dedent("""\
+            def register(registry):
+                raise RuntimeError('attacker code reached')
+        """))
+        with caplog.at_level("WARNING", logger="faultray.plugins.registry"):
+            PluginRegistry.load_plugins_from_dir(tmp_path)  # opt-in missing
+        assert any("Refusing to load" in r.message for r in caplog.records)
+        assert PluginRegistry.get_scenario_plugins() == []
+
+    def test_refuses_without_env_even_with_opt_in(self, tmp_path: Path, monkeypatch, caplog):
+        """Env empty → refused even with caller ``trusted=True``."""
+        monkeypatch.delenv("FAULTRAY_PLUGIN_TRUSTED_DIRS", raising=False)
+        canary = tmp_path / "boom.py"
+        canary.write_text(textwrap.dedent("""\
+            def register(registry):
+                raise RuntimeError('attacker code reached')
+        """))
+        with caplog.at_level("WARNING", logger="faultray.plugins.registry"):
+            PluginRegistry.load_plugins_from_dir(tmp_path, trusted=True)
+        assert any("Refusing to load" in r.message for r in caplog.records)
+        assert PluginRegistry.get_scenario_plugins() == []
+
+    def test_env_with_unrelated_path_still_refuses(self, tmp_path: Path, monkeypatch, caplog):
+        unrelated = tmp_path.parent / "definitely-not-this-path"
+        monkeypatch.setenv("FAULTRAY_PLUGIN_TRUSTED_DIRS", str(unrelated))
+        (tmp_path / "boom.py").write_text("def register(r):\n    raise RuntimeError('x')\n")
+        with caplog.at_level("WARNING", logger="faultray.plugins.registry"):
+            PluginRegistry.load_plugins_from_dir(tmp_path, trusted=True)
+        assert PluginRegistry.get_scenario_plugins() == []
+
+    def test_parent_dir_in_env_grants_trust(self, tmp_path: Path, monkeypatch):
+        """Parent listed in env → child dir treated as trusted."""
+        child = tmp_path / "child"
+        child.mkdir()
+        monkeypatch.setenv("FAULTRAY_PLUGIN_TRUSTED_DIRS", str(tmp_path))
+        (child / "p.py").write_text(textwrap.dedent("""\
+            class P:
+                name = "p"
+                description = ""
+                def generate_scenarios(self, *args, **kwargs): return []
+            def register(r):
+                r.register_scenario(P())
+        """))
+        PluginRegistry.load_plugins_from_dir(child, trusted=True)
+        assert len(PluginRegistry.get_scenario_plugins()) == 1
+
+
+class TestPluginMetadataAstReader:
+    """#149: PluginManager._read_metadata_from_file must not execute the file."""
+
+    def test_module_side_effects_are_not_triggered(self, tmp_path: Path):
+        """A plugin file with side-effects at import time must NOT execute."""
+        from faultray.plugins.plugin_manager import PluginManager
+
+        canary = tmp_path / "canary.txt"
+        plugin = tmp_path / "evil_plugin.py"
+        plugin.write_text(textwrap.dedent(f"""\
+            from pathlib import Path
+            Path({str(canary)!r}).write_text('PWNED')
+
+            PLUGIN_METADATA = {{
+                "name": "evil",
+                "version": "1.0",
+                "type": "scenario_generator",
+            }}
+        """))
+
+        meta = PluginManager._read_metadata_from_file(plugin)
+        assert meta is not None
+        assert meta.name == "evil"
+        assert not canary.exists(), "Plugin code executed during discovery (RCE)"
+
+    def test_non_literal_metadata_is_rejected(self, tmp_path: Path):
+        """``PLUGIN_METADATA`` built with non-literal expression is refused."""
+        from faultray.plugins.plugin_manager import PluginManager
+
+        plugin = tmp_path / "dynamic.py"
+        plugin.write_text(textwrap.dedent("""\
+            import os
+            PLUGIN_METADATA = {"name": os.environ.get("X", "y")}
+        """))
+
+        meta = PluginManager._read_metadata_from_file(plugin)
+        assert meta is None
+
+    def test_literal_metadata_is_parsed(self, tmp_path: Path):
+        from faultray.plugins.plugin_manager import PluginManager
+
+        plugin = tmp_path / "good.py"
+        plugin.write_text(textwrap.dedent("""\
+            PLUGIN_METADATA = {
+                "name": "good",
+                "version": "2.1.0",
+                "author": "me",
+                "type": "scenario_generator",
+                "dependencies": ["a", "b"],
+            }
+        """))
+        meta = PluginManager._read_metadata_from_file(plugin)
+        assert meta is not None
+        assert meta.name == "good"
+        assert meta.version == "2.1.0"
+        assert meta.dependencies == ["a", "b"]
+
+    def test_missing_metadata_returns_none(self, tmp_path: Path):
+        from faultray.plugins.plugin_manager import PluginManager
+
+        plugin = tmp_path / "empty.py"
+        plugin.write_text("# nothing here\n")
+        assert PluginManager._read_metadata_from_file(plugin) is None
+
+    def test_syntax_error_returns_none(self, tmp_path: Path):
+        from faultray.plugins.plugin_manager import PluginManager
+
+        plugin = tmp_path / "broken.py"
+        plugin.write_text("def broken(\n")
+        assert PluginManager._read_metadata_from_file(plugin) is None


### PR DESCRIPTION
## Summary
- Closes #149: switch ``PluginManager._read_metadata_from_file`` to AST + ``ast.literal_eval`` so discovery no longer executes the candidate ``.py`` files. Module side-effect tests prove no code runs (Path.write_text canary stays absent).
- Closes #150: ``PluginRegistry.load_plugins_from_dir`` now requires a kwarg-only ``trusted=True`` **and** the resolved path (or parent) to be listed in ``FAULTRAY_PLUGIN_TRUSTED_DIRS`` (os.pathsep separated). Either half missing fails closed with a warning.
- CLI ``simulate --plugins-dir`` gains a matching ``--trust-plugins-dir`` opt-in flag; without it, the registry call is skipped and the user is told why.

## Test plan
- [x] pytest tests/test_plugins.py tests/test_final_coverage.py::TestPluginLoadingException → 34 passed
- [x] ruff check src/faultray/plugins src/faultray/cli/simulate.py → clean
- [x] mypy --strict on changed regions reports no new errors
- [x] New TestLoadPluginsTrustGate covers opt-in missing / env missing / unrelated env / parent-dir grants
- [x] New TestPluginMetadataAstReader covers side-effect-free reading, non-literal rejection, missing-metadata, syntax error
