### PR TITLE
fix(api/auth): JWT signing harden + fail-closed permission wrapper (#137, #139)

### DIFF
--- a/src/faultray/api/oauth.py
+++ b/src/faultray/api/oauth.py
@@ -23,54 +23,90 @@ logger = logging.getLogger(__name__)
 # JWT helpers
 # ---------------------------------------------------------------------------
 
-_JWT_SECRET = (
-    os.environ.get("FAULTRAY_JWT_SECRET")
-    or os.environ.get("JWT_SECRET_KEY")
-    or "faultray-dev-secret-change-me"
-)
-if _JWT_SECRET == "faultray-dev-secret-change-me":
-    logger.warning(
-        "Using default JWT secret — set FAULTRAY_JWT_SECRET or JWT_SECRET_KEY for production"
-    )
 _JWT_ALGORITHM = "HS256"
 _JWT_EXPIRY_SECONDS = 86400  # 24 hours
 
+# Sentinel values that must never act as a real signing secret.
+_INSECURE_SECRETS: frozenset[str] = frozenset({
+    "faultray-dev-secret-change-me",
+    "change-me",
+    "REPLACE_ME",
+    "secret",
+    "",
+})
+
+
+def _require_jwt_secret() -> str:
+    """Return the configured JWT signing secret or raise.
+
+    #137: the previous module-level fallback to "faultray-dev-secret-change-me"
+    let any caller forge tokens with a publicly-known key, and the
+    ``except ImportError`` branches emitted/accepted unsigned base64 JSON
+    when python-jose was missing — turning a missing dependency into full
+    auth bypass. We now fail closed at first use: missing env, a sentinel
+    value, or a too-short secret all abort token issuance/verification
+    with a clear error.
+    """
+    secret = (
+        os.environ.get("FAULTRAY_JWT_SECRET")
+        or os.environ.get("JWT_SECRET_KEY")
+        or ""
+    )
+    if not secret or secret in _INSECURE_SECRETS:
+        raise RuntimeError(
+            "JWT signing secret is not configured. Set FAULTRAY_JWT_SECRET "
+            "(>= 32 random bytes) before issuing or verifying tokens."
+        )
+    if len(secret) < 32:
+        raise RuntimeError(
+            "JWT signing secret is too short (need >= 32 characters of "
+            "entropy). Set FAULTRAY_JWT_SECRET to a strong random value."
+        )
+    return secret
+
 
 def create_jwt(payload: dict[str, Any]) -> str:
-    """Create a signed JWT token."""
+    """Create a signed JWT token.
+
+    Raises ``RuntimeError`` if python-jose is unavailable or the signing
+    secret is missing/insecure. Both are bypass conditions — we refuse to
+    fall back to base64-only "tokens" or a known default key.
+    """
     try:
         from jose import jwt as jose_jwt
+    except ImportError as exc:  # pragma: no cover - declared in pyproject runtime deps
+        raise RuntimeError(
+            "python-jose is required for JWT auth. Install python-jose[cryptography]."
+        ) from exc
 
-        payload = {**payload, "exp": int(time.time()) + _JWT_EXPIRY_SECONDS,
-                   "iat": int(time.time())}
-        return jose_jwt.encode(payload, _JWT_SECRET, algorithm=_JWT_ALGORITHM)
-    except ImportError:
-        import base64
-        import json
-
-        payload = {**payload, "exp": int(time.time()) + _JWT_EXPIRY_SECONDS,
-                   "iat": int(time.time())}
-        return base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+    secret = _require_jwt_secret()
+    payload = {
+        **payload,
+        "exp": int(time.time()) + _JWT_EXPIRY_SECONDS,
+        "iat": int(time.time()),
+    }
+    return jose_jwt.encode(payload, secret, algorithm=_JWT_ALGORITHM)
 
 
 def decode_jwt(token: str) -> dict[str, Any] | None:
-    """Decode and verify a JWT token. Returns None if invalid/expired."""
+    """Decode and verify a JWT token. Returns ``None`` if invalid/expired.
+
+    Raises ``RuntimeError`` if python-jose is unavailable or the signing
+    secret is missing/insecure. A missing dependency must not silently
+    "validate" a forged base64 payload.
+    """
     try:
         from jose import jwt as jose_jwt
+        from jose.exceptions import JWTError
+    except ImportError as exc:  # pragma: no cover - declared in pyproject runtime deps
+        raise RuntimeError(
+            "python-jose is required for JWT auth. Install python-jose[cryptography]."
+        ) from exc
 
-        return jose_jwt.decode(token, _JWT_SECRET, algorithms=[_JWT_ALGORITHM])
-    except ImportError:
-        import base64
-        import json
-
-        try:
-            data = json.loads(base64.urlsafe_b64decode(token))
-            if data.get("exp", 0) < time.time():
-                return None
-            return data
-        except Exception:
-            return None
-    except Exception:
+    secret = _require_jwt_secret()
+    try:
+        return jose_jwt.decode(token, secret, algorithms=[_JWT_ALGORITHM])
+    except JWTError:
         return None
 
 # ---------------------------------------------------------------------------

--- a/src/faultray/api/routes/_shared.py
+++ b/src/faultray/api/routes/_shared.py
@@ -81,7 +81,15 @@ async def _optional_user(request: Request):
 
 
 def _require_permission(permission: str):
-    """Lazy wrapper around auth.require_permission (opt-in RBAC)."""
+    """Lazy wrapper around auth.require_permission (opt-in RBAC).
+
+    #139: previously this swallowed any non-HTTP exception from the auth
+    layer (DB outage, bad role config, import failure, ...) and returned
+    ``None``. Several route handlers use the dependency only for side
+    effects and ignore the returned principal, so a swallowed exception
+    silently became an *authorization bypass*. We now re-raise as 503
+    so the request is denied and operators see the failure.
+    """
     async def _dep(request: Request):
         try:
             from faultray.api.auth import require_permission
@@ -89,8 +97,15 @@ def _require_permission(permission: str):
             return await checker(request)
         except HTTPException:
             raise
-        except Exception:
-            return None
+        except Exception as exc:
+            logger.exception(
+                "auth layer raised unexpected exception in _require_permission(%r)",
+                permission,
+            )
+            raise HTTPException(
+                status_code=503,
+                detail="Authorization service is temporarily unavailable.",
+            ) from exc
     return _dep
 
 

--- a/tests/test_oauth_jwt.py
+++ b/tests/test_oauth_jwt.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2025-2026 Yutaro Maeda. All rights reserved.
+# Licensed under the Apache License 2.0. See LICENSE file for details.
+"""Regression tests for the JWT signing hardening (#137).
+
+Before #137 the JWT layer fell open in two independent ways: a publicly
+known default secret, and an ``ImportError`` branch that issued and
+accepted unsigned base64 JSON tokens whenever python-jose was missing.
+These tests pin the new fail-closed contract.
+"""
+from __future__ import annotations
+
+import pytest
+
+from faultray.api import oauth
+
+
+@pytest.fixture(autouse=True)
+def _clear_jwt_env(monkeypatch):
+    monkeypatch.delenv("FAULTRAY_JWT_SECRET", raising=False)
+    monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
+
+
+def test_require_jwt_secret_raises_when_unset() -> None:
+    with pytest.raises(RuntimeError, match="JWT signing secret is not configured"):
+        oauth._require_jwt_secret()
+
+
+@pytest.mark.parametrize(
+    "sentinel",
+    [
+        "faultray-dev-secret-change-me",
+        "change-me",
+        "REPLACE_ME",
+        "secret",
+        "",
+    ],
+)
+def test_require_jwt_secret_rejects_known_insecure_values(monkeypatch, sentinel: str) -> None:
+    monkeypatch.setenv("FAULTRAY_JWT_SECRET", sentinel)
+    with pytest.raises(RuntimeError, match="not configured"):
+        oauth._require_jwt_secret()
+
+
+def test_require_jwt_secret_rejects_short_value(monkeypatch) -> None:
+    monkeypatch.setenv("FAULTRAY_JWT_SECRET", "x" * 31)
+    with pytest.raises(RuntimeError, match="too short"):
+        oauth._require_jwt_secret()
+
+
+def test_require_jwt_secret_accepts_strong_value(monkeypatch) -> None:
+    secret = "x" * 64
+    monkeypatch.setenv("FAULTRAY_JWT_SECRET", secret)
+    assert oauth._require_jwt_secret() == secret
+
+
+def test_create_jwt_refuses_without_secret() -> None:
+    with pytest.raises(RuntimeError):
+        oauth.create_jwt({"sub": "u1"})
+
+
+def test_decode_jwt_refuses_without_secret() -> None:
+    with pytest.raises(RuntimeError):
+        oauth.decode_jwt("not-a-token")
+
+
+def test_signed_token_roundtrip(monkeypatch) -> None:
+    monkeypatch.setenv("FAULTRAY_JWT_SECRET", "z" * 64)
+    token = oauth.create_jwt({"sub": "user-123"})
+    # Real JWT shape: three base64url segments separated by dots.
+    assert token.count(".") == 2
+    decoded = oauth.decode_jwt(token)
+    assert decoded is not None
+    assert decoded["sub"] == "user-123"
+
+
+def test_decode_jwt_rejects_forgery_with_different_secret(monkeypatch) -> None:
+    monkeypatch.setenv("FAULTRAY_JWT_SECRET", "a" * 64)
+    token = oauth.create_jwt({"sub": "victim"})
+
+    monkeypatch.setenv("FAULTRAY_JWT_SECRET", "b" * 64)
+    # Same token, different signing key — must fail verification.
+    assert oauth.decode_jwt(token) is None
+
+
+def test_decode_jwt_rejects_base64_only_payload(monkeypatch) -> None:
+    """#137: a bare base64-encoded JSON blob must NOT validate as a JWT.
+
+    The old ImportError path treated such blobs as valid sessions if the
+    payload had an unexpired ``exp``. Now even a perfectly-shaped fake
+    must be rejected.
+    """
+    import base64
+    import json
+    import time
+
+    monkeypatch.setenv("FAULTRAY_JWT_SECRET", "c" * 64)
+    forged = base64.urlsafe_b64encode(
+        json.dumps({"sub": "admin", "exp": int(time.time()) + 3600}).encode()
+    ).decode()
+    assert oauth.decode_jwt(forged) is None

--- a/tests/test_saas.py
+++ b/tests/test_saas.py
@@ -128,6 +128,12 @@ class TestOAuthCallback:
 class TestJWT:
     """Tests for JWT creation and decoding."""
 
+    @pytest.fixture(autouse=True)
+    def _set_jwt_secret(self, monkeypatch):
+        """#137: create_jwt / decode_jwt now refuse to run without a real signing
+        secret. These tests exercise the happy path, so seed a strong test value."""
+        monkeypatch.setenv("FAULTRAY_JWT_SECRET", "x" * 64)
+
     def test_create_and_decode_jwt(self):
         from faultray.api.oauth import create_jwt, decode_jwt
 

--- a/tests/test_shared_require_permission.py
+++ b/tests/test_shared_require_permission.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2025-2026 Yutaro Maeda. All rights reserved.
+# Licensed under the Apache License 2.0. See LICENSE file for details.
+"""Regression tests for #139 — _require_permission must fail closed.
+
+Before #139, any non-HTTPException from the auth layer (DB outage, role
+config error, ImportError, ...) was swallowed and the dependency
+returned ``None``. Many handlers ignore the principal and only use the
+dependency for side effects, so the swallowed exception became a
+silent authorization bypass. These tests pin the new contract:
+
+- HTTPException raised by the auth layer is propagated unchanged
+  (preserving the existing 401 / 403 contract).
+- Any other exception is converted to a 503 so the request is denied.
+- Happy path: when the auth layer returns a value, the dependency
+  returns it (no regression on normal behavior).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from faultray.api.routes import _shared
+
+
+class _FakeRequest:
+    """Minimal stand-in for fastapi.Request — never actually used."""
+
+
+@pytest.fixture
+def patch_require_permission(monkeypatch):
+    """Replace faultray.api.auth.require_permission with a controllable double."""
+
+    def _install(behavior):
+        async def _checker(_request: Any) -> Any:
+            return behavior()
+
+        def _require_permission(_permission: str):
+            return _checker
+
+        import sys
+        import types
+
+        mod = types.ModuleType("faultray.api.auth")
+        mod.require_permission = _require_permission  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "faultray.api.auth", mod)
+
+    return _install
+
+
+@pytest.mark.asyncio
+async def test_happy_path_returns_principal(patch_require_permission) -> None:
+    patch_require_permission(lambda: {"user_id": "u1", "permission": "view"})
+    dep = _shared._require_permission("view")
+    result = await dep(_FakeRequest())
+    assert result == {"user_id": "u1", "permission": "view"}
+
+
+@pytest.mark.asyncio
+async def test_http_exception_propagates_unchanged(patch_require_permission) -> None:
+    def _raise():
+        raise HTTPException(status_code=403, detail="not allowed")
+
+    patch_require_permission(_raise)
+    dep = _shared._require_permission("view")
+    with pytest.raises(HTTPException) as exc_info:
+        await dep(_FakeRequest())
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "not allowed"
+
+
+@pytest.mark.asyncio
+async def test_generic_exception_is_converted_to_503(patch_require_permission) -> None:
+    """#139: a DB error must NOT silently allow the request through."""
+
+    def _raise():
+        raise RuntimeError("simulated auth-layer/DB failure")
+
+    patch_require_permission(_raise)
+    dep = _shared._require_permission("manage_billing")
+    with pytest.raises(HTTPException) as exc_info:
+        await dep(_FakeRequest())
+    assert exc_info.value.status_code == 503
+    assert "Authorization service" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_import_failure_is_converted_to_503(monkeypatch) -> None:
+    """Even an ImportError on the auth module must fail closed."""
+    import sys
+
+    monkeypatch.setitem(
+        sys.modules,
+        "faultray.api.auth",
+        None,  # forces ImportError on `from faultray.api.auth import ...`
+    )
+    dep = _shared._require_permission("view")
+    with pytest.raises(HTTPException) as exc_info:
+        await dep(_FakeRequest())
+    assert exc_info.value.status_code == 503


### PR DESCRIPTION
## Summary
- Closes #137: removed the publicly-known JWT secret fallback and the unsigned base64 ``ImportError`` branch. Both create_jwt / decode_jwt now require python-jose plus a configured FAULTRAY_JWT_SECRET >= 32 chars, refusing known sentinels (``faultray-dev-secret-change-me`` etc.).
- Closes #139: ``_shared._require_permission`` no longer swallows non-HTTP exceptions into a silent None; auth-layer failures now log + raise HTTPException(503). HTTPException paths still propagate so the existing 401/403 contract is preserved.

## Out of scope (Wave 2)
- #136 .env secret rotation + .dockerignore audit
- #138 v1 SaaS routes placeholder auth delegation
- #140 ``/setup`` bootstrap gating

## Test plan
- [x] pytest tests/test_oauth_jwt.py tests/test_shared_require_permission.py → **17 passed**
- [x] ruff check on changed files → clean
- [x] JWT test covers: secret unset, 5 known sentinels rejected, < 32 chars rejected, signed roundtrip, cross-secret forgery rejected, bare base64 forgery rejected
- [x] _require_permission test covers: happy path, HTTPException pass-through, RuntimeError → 503, ImportError → 503
