### PR TITLE
fix(marketing): read DEVTO_API_KEY from env (#148)

### DIFF
--- a/marketing/publish-devto.sh
+++ b/marketing/publish-devto.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Publish marketing/devto-article.md to dev.to via the v1 articles API.
+# Run from the developer machine (not WSL).
+#
+# Usage:
+#   chmod +x publish-devto.sh
+#   DEVTO_API_KEY=... ./publish-devto.sh
+#
+# #148: the API key is read from the environment instead of being baked
+# into the script. Set it inline (`DEVTO_API_KEY=... ./publish-devto.sh`)
+# to keep it out of shell history (when your shell is configured to skip
+# space-prefixed lines) and out of git entirely.
+
+set -euo pipefail
+
+if [[ -z "${DEVTO_API_KEY:-}" ]]; then
+  echo "error: DEVTO_API_KEY is not set." >&2
+  echo "       Generate one at https://dev.to/settings/extensions and run as:" >&2
+  echo "       DEVTO_API_KEY=... ./publish-devto.sh" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ARTICLE="${SCRIPT_DIR}/devto-article.md"
+
+if [[ ! -f "${ARTICLE}" ]]; then
+  echo "error: article not found at ${ARTICLE}" >&2
+  exit 1
+fi
+
+# Strip the leading --- ... --- frontmatter block.
+BODY=$(sed '1{/^---$/d}; /^---$/,/^---$/d' "${ARTICLE}")
+
+PAYLOAD=$(python3 - "$BODY" <<'PY'
+import json, sys
+
+body = sys.argv[1]
+payload = {
+    "article": {
+        "title": "How We Simulate 2,000+ Infrastructure Failures Without Touching Production",
+        "body_markdown": body,
+        "published": True,
+        "tags": ["chaosengineering", "devops", "python", "terraform"],
+        "description": "FaultRay scores your infrastructure resilience before terraform apply — catching cascade risks, SPOFs, and availability ceiling violations in seconds.",
+    }
+}
+print(json.dumps(payload))
+PY
+)
+
+curl -fsS -X POST "https://dev.to/api/articles" \
+  -H "api-key: ${DEVTO_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "${PAYLOAD}" | python3 -m json.tool
+
+echo
+echo "Done. Check the URL above."

--- a/tests/test_saas.py
+++ b/tests/test_saas.py
@@ -128,12 +128,6 @@ class TestOAuthCallback:
 class TestJWT:
     """Tests for JWT creation and decoding."""
 
-    @pytest.fixture(autouse=True)
-    def _set_jwt_secret(self, monkeypatch):
-        """#137: create_jwt / decode_jwt now refuse to run without a real signing
-        secret. These tests exercise the happy path, so seed a strong test value."""
-        monkeypatch.setenv("FAULTRAY_JWT_SECRET", "x" * 64)
-
     def test_create_and_decode_jwt(self):
         from faultray.api.oauth import create_jwt, decode_jwt
 

--- a/tests/test_saas.py
+++ b/tests/test_saas.py
@@ -128,6 +128,12 @@ class TestOAuthCallback:
 class TestJWT:
     """Tests for JWT creation and decoding."""
 
+    @pytest.fixture(autouse=True)
+    def _set_jwt_secret(self, monkeypatch):
+        """#137: create_jwt / decode_jwt now refuse to run without a real signing
+        secret. These tests exercise the happy path, so seed a strong test value."""
+        monkeypatch.setenv("FAULTRAY_JWT_SECRET", "x" * 64)
+
     def test_create_and_decode_jwt(self):
         from faultray.api.oauth import create_jwt, decode_jwt
 


### PR DESCRIPTION
## Summary
- Closes #148: ``marketing/publish-devto.sh`` no longer carries a real dev.to API key. The script now reads ``DEVTO_API_KEY`` from the environment and refuses to run without it.
- The file was previously *untracked* so it never reached git history, but it sat in the working tree and any disk image. This PR replaces it with a token-free version and ships it as tracked code.

## Manual follow-up
- Rotate the previously-hardcoded key at https://dev.to/settings/extensions even though it was never committed.

## Test plan
- [x] ``bash -n marketing/publish-devto.sh`` (syntax) passes
- [x] running without DEVTO_API_KEY prints the help message and exits 1
- [x] no occurrences of the literal token remain (``grep`` clean)

## Notes
Other shell hygiene tightened in the same change: ``set -euo pipefail``, ``curl -fsS`` so HTTP errors fail the script, absolute-path article resolution, and an explicit env-missing error.
