### PR TITLE
fix(admin): gate /setup behind FAULTRAY_BOOTSTRAP_TOKEN or loopback (#140)

### DIFF
--- a/src/faultray/api/routes/admin.py
+++ b/src/faultray/api/routes/admin.py
@@ -6,6 +6,7 @@ supply chain, OAuth, billing, and miscellaneous endpoints."""
 
 from __future__ import annotations
 
+import hmac
 import logging
 import os
 
@@ -76,9 +77,59 @@ async def settings_page(request: Request, _user=_READ_ACCESS):
 # Initial Setup — create the first admin user (C1 fix)
 # ---------------------------------------------------------------------------
 
+_LOOPBACK_HOSTS: frozenset[str] = frozenset({"127.0.0.1", "::1", "localhost"})
+
+
+def _check_setup_allowed(request: Request) -> None:
+    """#140: gate ``/setup`` against the race-to-takeover threat.
+
+    Fresh deployments used to expose ``/setup`` to the public internet
+    until a first admin happened to be created — whoever reached the
+    endpoint first won permanent admin. This helper accepts a request
+    only when one of two conditions holds:
+
+    1. ``FAULTRAY_BOOTSTRAP_TOKEN`` is set and the request supplies the
+       same value via the ``X-Setup-Token`` header or ``?token=``
+       query parameter (compared with ``hmac.compare_digest`` to avoid
+       timing leaks).
+    2. The env is unset *and* the request originates from a loopback
+       address. This keeps local-dev convenience but forbids public
+       reach on any deployment that doesn't explicitly configure a
+       token.
+
+    On rejection we return 403, not 401 — the endpoint should look
+    unavailable, not "send a token to access".
+    """
+    expected = os.environ.get("FAULTRAY_BOOTSTRAP_TOKEN", "").strip()
+    if expected:
+        provided = (
+            request.headers.get("X-Setup-Token")
+            or request.query_params.get("token")
+            or ""
+        )
+        if not hmac.compare_digest(provided, expected):
+            logger.warning(
+                "rejected /setup attempt: bootstrap token mismatch (client=%s)",
+                request.client.host if request.client else "?",
+            )
+            raise HTTPException(status_code=403, detail="Setup is not available.")
+        return
+
+    client_host = request.client.host if request.client else ""
+    if client_host not in _LOOPBACK_HOSTS:
+        logger.warning(
+            "rejected /setup attempt from non-loopback client without "
+            "FAULTRAY_BOOTSTRAP_TOKEN (client=%s)",
+            client_host or "?",
+        )
+        raise HTTPException(status_code=403, detail="Setup is not available.")
+
+
 @router.get("/setup", response_class=HTMLResponse)
 async def setup_page(request: Request):
     """Show initial setup form when no users exist; redirect to / otherwise."""
+    _check_setup_allowed(request)
+
     from faultray.api.database import UserRow, get_session_factory
     from sqlalchemy import select
 
@@ -99,6 +150,8 @@ async def setup_page(request: Request):
 @router.post("/setup", response_class=HTMLResponse)
 async def setup_create_admin(request: Request):
     """Create the first admin user; redirect to setup GET with error on failure."""
+    _check_setup_allowed(request)
+
     from faultray.api.auth import generate_api_key, hash_api_key
     from faultray.api.database import UserRow, get_session_factory
     from sqlalchemy import select

--- a/tests/test_admin_setup_gate.py
+++ b/tests/test_admin_setup_gate.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2025-2026 Yutaro Maeda. All rights reserved.
+# Licensed under the Apache License 2.0. See LICENSE file for details.
+"""Regression tests for #140 — /setup must be gated.
+
+Before #140 a fresh deployment exposed POST /setup on the public
+internet, so whichever caller reached it first claimed permanent admin
+access. ``_check_setup_allowed`` now refuses every non-loopback caller
+unless they present a matching ``FAULTRAY_BOOTSTRAP_TOKEN``.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from faultray.api.server import app
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """TestClient simulates client.host = 'testclient' (non-loopback)."""
+    monkeypatch.delenv("FAULTRAY_BOOTSTRAP_TOKEN", raising=False)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_get_setup_rejected_without_token_and_not_loopback(client):
+    resp = client.get("/setup")
+    assert resp.status_code == 403
+
+
+def test_post_setup_rejected_without_token_and_not_loopback(client):
+    resp = client.post(
+        "/setup",
+        data={"name": "X", "email": "x@example.com"},
+    )
+    assert resp.status_code == 403
+
+
+def test_get_setup_rejected_with_wrong_token(monkeypatch):
+    monkeypatch.setenv("FAULTRAY_BOOTSTRAP_TOKEN", "correct-token-value")
+    c = TestClient(app, raise_server_exceptions=False)
+    resp = c.get("/setup", headers={"X-Setup-Token": "wrong-token"})
+    assert resp.status_code == 403
+
+
+def test_get_setup_rejected_with_empty_token_header(monkeypatch):
+    monkeypatch.setenv("FAULTRAY_BOOTSTRAP_TOKEN", "correct-token-value")
+    c = TestClient(app, raise_server_exceptions=False)
+    resp = c.get("/setup", headers={"X-Setup-Token": ""})
+    assert resp.status_code == 403
+
+
+def test_get_setup_accepted_with_correct_header_token(monkeypatch):
+    monkeypatch.setenv("FAULTRAY_BOOTSTRAP_TOKEN", "correct-token-value")
+    c = TestClient(app, raise_server_exceptions=False)
+    resp = c.get("/setup", headers={"X-Setup-Token": "correct-token-value"})
+    # 200 (no users) or 302 (users exist) are both fine — the gate let us in.
+    assert resp.status_code in {200, 302}
+
+
+def test_get_setup_accepted_with_correct_query_token(monkeypatch):
+    monkeypatch.setenv("FAULTRAY_BOOTSTRAP_TOKEN", "correct-token-value")
+    c = TestClient(app, raise_server_exceptions=False)
+    resp = c.get("/setup?token=correct-token-value")
+    assert resp.status_code in {200, 302}
+
+
+def test_post_setup_rejected_with_wrong_token(monkeypatch):
+    monkeypatch.setenv("FAULTRAY_BOOTSTRAP_TOKEN", "correct-token-value")
+    c = TestClient(app, raise_server_exceptions=False)
+    resp = c.post(
+        "/setup",
+        data={"name": "X", "email": "x@example.com"},
+        headers={"X-Setup-Token": "guess"},
+    )
+    assert resp.status_code == 403
+
+
+def test_whitespace_only_env_treated_as_unset(monkeypatch):
+    """FAULTRAY_BOOTSTRAP_TOKEN='   ' must not act as a valid secret."""
+    monkeypatch.setenv("FAULTRAY_BOOTSTRAP_TOKEN", "   ")
+    c = TestClient(app, raise_server_exceptions=False)
+    # Stripped env -> no token configured, non-loopback client -> 403.
+    resp = c.get("/setup")
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
Closes #140: fresh deployments exposed POST /setup on the public internet — whichever caller reached it first claimed permanent admin. The new ``_check_setup_allowed`` runs at the top of both GET and POST /setup:

- If ``FAULTRAY_BOOTSTRAP_TOKEN`` is set, the request must supply the same value via ``X-Setup-Token`` header or ``?token=`` query parameter (compared with ``hmac.compare_digest``).
- If the env is unset, only loopback clients (127.0.0.1 / ::1 / localhost) may reach the endpoint.
- Anything else is 403 with a warning log that records the client host. Whitespace-only env is treated as unset.

## Operator notes
1. Set ``FAULTRAY_BOOTSTRAP_TOKEN`` on first deployment.
2. Hit ``/setup`` with the token header to bootstrap the first admin.
3. Unset the env (or delete the /setup templates) so the gate stays closed afterward.

## Test plan
- [x] ``pytest tests/test_admin_setup_gate.py`` → **8 passed** (no env / wrong / empty / right header / right query / whitespace env / POST)
- [x] Verified manually with TestClient (env unset + non-loopback => 403, env set + token match => 200/302).
