### PR TITLE
ci: install PR source + pin and gate CLA action (#144, #152)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,4 +1,15 @@
 name: CLA Assistant
+
+# #152: this workflow runs with write privileges via pull_request_target
+# (so the action can update statuses / comments on PRs from forks).
+# Hardenings applied:
+#   - issue_comment trigger is narrowed in the job ``if`` to the two
+#     phrases the action actually consumes (``recheck`` /
+#     ``I have read the CLA ...``); all other comments early-exit before
+#     any code runs.
+#   - the third-party action is pinned to the exact commit SHA matching
+#     tag v2.6.1, so a re-tag of v2.6.1 by an upstream attacker can't
+#     drive write-capable code on this repo.
 on:
   issue_comment:
     types: [created]
@@ -15,8 +26,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: CLA Assistant
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        # #152: explicit allowlist for the comment-driven path.
+        if: |
+          github.event_name == 'pull_request_target'
+          || (
+            github.event_name == 'issue_comment'
+            && github.event.issue.pull_request != null
+            && (
+              github.event.comment.body == 'recheck'
+              || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+            )
+          )
+        # #152: pinned to the commit SHA of contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08  # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/faultray-pr-check.yml
+++ b/.github/workflows/faultray-pr-check.yml
@@ -25,8 +25,13 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install FaultRay
-        run: pip install faultray  # or pip install -e . if in same repo
+      - name: Install FaultRay (from the PR's checked-out source)
+        # #144: previously this ran ``pip install faultray`` (the PyPI
+        # release), which silently shadowed the working tree — every
+        # analyzer / CLI / workflow change in the PR was ignored by the
+        # gate. Install the local source in editable mode so the check
+        # actually exercises the PR being reviewed.
+        run: pip install -e .
 
       - name: Find infrastructure YAML files
         id: find-yaml


### PR DESCRIPTION
## Summary
Closes #144: ``faultray-pr-check.yml`` installed the PyPI release of FaultRay, so any change in the PR was shadowed by the published wheel. Now installs the checked-out source (``pip install -e .``) so the gate actually tests the PR.

Closes #152: ``cla.yml`` runs with ``contents: write`` / ``pull-requests: write`` via ``pull_request_target`` and pulled ``contributor-assistant/github-action@v2.6.1`` — a tag, not an immutable commit. Two hardenings:
- Pin to commit SHA ``ca4a40a7d1004f18d9960b404b97e5f30a505a08`` (matches the v2.6.1 tag at time of writing).
- Narrow the issue_comment branch to ``recheck`` or the explicit signature phrase; any other comment short-circuits before action code runs.

## Test plan
- [x] ``python3 -c "import yaml; yaml.safe_load(open(\".github/workflows/cla.yml\")); ..."`` → both YAML files parse
- [x] SHA resolved via GitHub API: ``GET /repos/contributor-assistant/github-action/git/refs/tags/v2.6.1`` returned ``ca4a40a7d1004f18d9960b404b97e5f30a505a08``
