### PR TITLE
fix(deps): add python-multipart to core dependencies (clean-install /setup 500)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+- **Packaging**: `python-multipart` added to core dependencies — `/setup`, simulation and graph form endpoints returned 500 (`AssertionError: The python-multipart library must be installed`) on a clean install
 - **Security**: Team Workspace API (`/api/teams/*`) endpoints now require authentication/RBAC (previously unauthenticated)
 - **Security**: `/api/v1` SaaS route permission checker now enforces real RBAC instead of allowing anonymous access
 - **Security**: JWT secret falls back to the dev default only outside production; `FAULTRAY_ENV=production` without `FAULTRAY_JWT_SECRET` now fails fast

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ dependencies = [
     "networkx>=3.0",
     "psutil>=7.2.2",
     "fastapi>=0.115",
+    # Form parsing (/setup, simulation and graph upload routes) — without
+    # this a clean install 500s on those endpoints. >=0.0.18: CVE-2024-53981.
+    "python-multipart>=0.0.18",
     "itsdangerous>=2.1",
     "uvicorn>=0.34",
     "jinja2>=3.1.6",


### PR DESCRIPTION
Follow-up to #168, found during runtime verification of the merge.

The `/setup` admin form, simulation upload and graph upload routes all call `request.form()`, which starlette refuses without `python-multipart` — a clean `pip install faultray` + `faultray serve` returned **500** (`AssertionError: The python-multipart library must be installed`) on those endpoints.

- Added `python-multipart>=0.0.18` to core dependencies (0.0.18 = CVE-2024-53981 boundary-parsing DoS fix)
- Verified end-to-end in a fresh venv: clean install resolves 0.0.32, `faultray serve` + `POST /setup` now returns 200 and issues the admin API key

https://claude.ai/code/session_01Fpe2z3KCqdYVPVo574N3Pu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fpe2z3KCqdYVPVo574N3Pu)_