### PR TITLE
fix(security): resolve open Codex-audit issues (auth, plugin RCE, CI, secrets hardening)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -15,8 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: CLA Assistant
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        # Comment triggers only fire on PR comments (not plain issues), and the
+        # third-party action is pinned to an immutable commit SHA to remove the
+        # floating-tag supply-chain risk on this write-capable workflow.
+        if: |
+          (github.event_name == 'issue_comment'
+            && github.event.issue.pull_request
+            && (github.event.comment.body == 'recheck'
+                || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'))
+          || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08  # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/faultray-pr-check.yml
+++ b/.github/workflows/faultray-pr-check.yml
@@ -26,7 +26,9 @@ jobs:
           python-version: '3.11'
 
       - name: Install FaultRay
-        run: pip install faultray  # or pip install -e . if in same repo
+        # Install the checked-out code under review, not a published build,
+        # so the gate actually validates the PR's changes.
+        run: pip install -e .
 
       - name: Find infrastructure YAML files
         id: find-yaml

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,9 @@ docs/proposal/executive-report.html
 *.synctex.gz
 paper/*.log
 paper/*.out
+
+# Secrets & legal strategy — never commit (issues #136 #147 #148)
+.env.*
+*.env
+docs/patent/
+marketing/publish-*.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,10 @@ repos:
           - types-PyYAML>=6.0
           - types-networkx>=3.0
         args: [--ignore-missing-imports]
+  # Block hardcoded secrets at commit time (defense-in-depth alongside the
+  # gitleaks CI workflow), so tokens like the ones flagged in #136/#148 cannot
+  # be reintroduced locally.
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.4
+    hooks:
+      - id: gitleaks

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
-# FaultRay v11.0.0 Release Script
+# FaultRay Release Script
 # Run this AFTER patent filing is complete
 
 set -e
 
-VERSION="11.0.0"
+# Derive the version from pyproject.toml so the tag and artifacts always match
+# the package metadata (a hardcoded value drifts and uploads the wrong dist/).
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="$(python3 -c "import tomllib; print(tomllib.load(open('${REPO_ROOT}/pyproject.toml','rb'))['project']['version'])")"
+
+if [ -z "${VERSION}" ]; then
+  echo "ERROR: could not read version from pyproject.toml" >&2
+  exit 1
+fi
 
 echo "=== FaultRay v${VERSION} Release ==="
 

--- a/src/faultray/api/insurance_api.py
+++ b/src/faultray/api/insurance_api.py
@@ -507,7 +507,7 @@ async def score_infrastructure(request: ScoreRequest) -> JSONResponse:
     except Exception as exc:
         logger.warning("Insurance scoring failed: %s", exc, exc_info=True)
         return JSONResponse(
-            {"error": f"Failed to compute insurance score: {exc}"},
+            {"error": "Failed to compute insurance score. Check the submitted model and try again."},
             status_code=400,
         )
 

--- a/src/faultray/api/oauth.py
+++ b/src/faultray/api/oauth.py
@@ -42,39 +42,43 @@ _JWT_EXPIRY_SECONDS = 86400  # 24 hours
 
 
 def create_jwt(payload: dict[str, Any]) -> str:
-    """Create a signed JWT token."""
+    """Create a signed JWT token.
+
+    Requires ``python-jose``. We deliberately do NOT fall back to an unsigned
+    token when the library is missing: an unsigned, attacker-forgeable blob
+    accepted as a credential is an authentication bypass (see decode_jwt).
+    """
     try:
         from jose import jwt as jose_jwt
+    except ImportError as exc:
+        raise RuntimeError(
+            "JWT issuance requires 'python-jose'. Install it "
+            "(pip install 'faultray[saas]') or use API-key authentication."
+        ) from exc
 
-        payload = {**payload, "exp": int(time.time()) + _JWT_EXPIRY_SECONDS,
-                   "iat": int(time.time())}
-        return jose_jwt.encode(payload, _JWT_SECRET, algorithm=_JWT_ALGORITHM)
-    except ImportError:
-        import base64
-        import json
-
-        payload = {**payload, "exp": int(time.time()) + _JWT_EXPIRY_SECONDS,
-                   "iat": int(time.time())}
-        return base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+    payload = {**payload, "exp": int(time.time()) + _JWT_EXPIRY_SECONDS,
+               "iat": int(time.time())}
+    return jose_jwt.encode(payload, _JWT_SECRET, algorithm=_JWT_ALGORITHM)
 
 
 def decode_jwt(token: str) -> dict[str, Any] | None:
-    """Decode and verify a JWT token. Returns None if invalid/expired."""
+    """Decode and verify a signed JWT. Returns None if invalid/expired.
+
+    Fails closed when ``python-jose`` is unavailable: rather than trusting an
+    unsigned base64 payload (which anyone could forge), we reject all JWTs so
+    the caller falls back to API-key authentication.
+    """
     try:
         from jose import jwt as jose_jwt
-
-        return jose_jwt.decode(token, _JWT_SECRET, algorithms=[_JWT_ALGORITHM])
     except ImportError:
-        import base64
-        import json
+        logger.warning(
+            "python-jose not installed; rejecting JWT (no signature verification "
+            "available). Install 'faultray[saas]' to enable JWT auth."
+        )
+        return None
 
-        try:
-            data = json.loads(base64.urlsafe_b64decode(token))
-            if data.get("exp", 0) < time.time():
-                return None
-            return data
-        except Exception:
-            return None
+    try:
+        return jose_jwt.decode(token, _JWT_SECRET, algorithms=[_JWT_ALGORITHM])
     except Exception:
         return None
 

--- a/src/faultray/api/routes/_shared.py
+++ b/src/faultray/api/routes/_shared.py
@@ -81,7 +81,11 @@ async def _optional_user(request: Request):
 
 
 def _require_permission(permission: str):
-    """Lazy wrapper around auth.require_permission (opt-in RBAC)."""
+    """Lazy wrapper around auth.require_permission (opt-in RBAC).
+
+    Fails closed: an unexpected error in the auth layer (DB outage, bad role
+    value, import failure) must deny the request, never silently grant it.
+    """
     async def _dep(request: Request):
         try:
             from faultray.api.auth import require_permission
@@ -90,7 +94,10 @@ def _require_permission(permission: str):
         except HTTPException:
             raise
         except Exception:
-            return None
+            logger.exception("Authorization check failed unexpectedly; denying request")
+            raise HTTPException(
+                status_code=500, detail="Authorization check failed"
+            )
     return _dep
 
 

--- a/src/faultray/api/routes/admin.py
+++ b/src/faultray/api/routes/admin.py
@@ -113,6 +113,32 @@ async def setup_create_admin(request: Request):
         return RedirectResponse(url="/", status_code=302)
 
     form = await request.form()
+
+    # Optional bootstrap gate: when FAULTRAY_SETUP_TOKEN is configured, the very
+    # first-admin creation must present a matching token (form field or header).
+    # This closes the "race to takeover" on a fresh, internet-reachable instance
+    # (#140) while leaving the default first-run UX unchanged when unset.
+    import os as _os
+
+    setup_token = _os.environ.get("FAULTRAY_SETUP_TOKEN", "")
+    if setup_token:
+        import hmac as _hmac
+
+        provided = str(
+            form.get("setup_token") or request.headers.get("X-Setup-Token", "")
+        )
+        if not _hmac.compare_digest(provided, setup_token):
+            logger.warning("Rejected /setup attempt: missing/invalid setup token")
+            return templates.TemplateResponse(
+                request,
+                "setup.html",
+                {
+                    "success": False,
+                    "error": "A valid setup token is required to create the first admin.",
+                },
+                status_code=403,
+            )
+
     name = str(form.get("name", "")).strip()
     email = str(form.get("email", "")).strip()
 

--- a/src/faultray/api/routes/simulation.py
+++ b/src/faultray/api/routes/simulation.py
@@ -56,11 +56,9 @@ async def simulation_run_get():
     set_last_report(report)
     report_dict = _report_to_dict(report)
 
-    # Persist to database
-    run_id = await _save_run(report_dict, engine_type="static")
-    if run_id is not None:
-        report_dict["run_id"] = run_id
-
+    # This endpoint is public (demo/dashboard). It intentionally does NOT
+    # persist a run row: anonymous traffic must not write unbounded shared
+    # state. Authenticated run persistence is handled by the /api/v1 routes.
     return JSONResponse(report_dict)
 
 

--- a/src/faultray/cli/simulate.py
+++ b/src/faultray/cli/simulate.py
@@ -243,12 +243,17 @@ def simulate(
         console.print("Run [cyan]faultray scan[/] first to create a model.")
         raise typer.Exit(1)
 
-    # Load plugins if a directory is specified
+    # Load plugins if a directory is specified. Naming --plugins-dir is the
+    # user's explicit opt-in to execute that directory's code, so we pass
+    # trusted=True but surface a clear security notice first.
     if plugins_dir is not None:
         from faultray.plugins.registry import PluginRegistry
 
-        console.print(f"[cyan]Loading plugins from {plugins_dir}...[/]")
-        PluginRegistry.load_plugins_from_dir(plugins_dir)
+        console.print(
+            f"[yellow]Loading plugins from {plugins_dir} — this executes Python "
+            f"from that directory. Only use directories you trust.[/]"
+        )
+        PluginRegistry.load_plugins_from_dir(plugins_dir, trusted=True)
 
     if json_output:
         # Suppress logging to stdout so JSON output is parseable

--- a/src/faultray/plugins/plugin_manager.py
+++ b/src/faultray/plugins/plugin_manager.py
@@ -20,6 +20,7 @@ Plugin discovery:
 
 from __future__ import annotations
 
+import ast
 import importlib
 import importlib.util
 import logging
@@ -483,16 +484,42 @@ class PluginManager:
         return found
 
     @staticmethod
-    def _read_metadata_from_file(py_file: Path) -> PluginMetadata | None:
-        """Extract ``PLUGIN_METADATA`` dict from a Python source file."""
-        try:
-            spec = importlib.util.spec_from_file_location(py_file.stem, py_file)
-            if spec is None or spec.loader is None:
-                return None
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)  # type: ignore[union-attr]
+    def _extract_metadata_literal(py_file: Path) -> dict | None:
+        """Statically read a ``PLUGIN_METADATA = {...}`` literal via AST.
 
-            raw = getattr(module, "PLUGIN_METADATA", None)
+        Returns the dict if it is a pure literal (``ast.literal_eval``-able),
+        else None. Never imports or executes the file.
+        """
+        try:
+            source = py_file.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=str(py_file))
+        except (OSError, SyntaxError, ValueError):
+            return None
+
+        for node in tree.body:
+            if not isinstance(node, ast.Assign):
+                continue
+            targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+            if "PLUGIN_METADATA" not in targets:
+                continue
+            try:
+                value = ast.literal_eval(node.value)
+            except (ValueError, SyntaxError):
+                return None
+            return value if isinstance(value, dict) else None
+        return None
+
+    @staticmethod
+    def _read_metadata_from_file(py_file: Path) -> PluginMetadata | None:
+        """Extract ``PLUGIN_METADATA`` dict from a Python source file.
+
+        Parses the source with the ``ast`` module and statically evaluates the
+        ``PLUGIN_METADATA`` literal. The file is **not** imported or executed,
+        so merely discovering/listing plugins can never run third-party code
+        (the discovery path must stay safe even for untrusted directories).
+        """
+        try:
+            raw = PluginManager._extract_metadata_literal(py_file)
             if not isinstance(raw, dict):
                 return None
 

--- a/src/faultray/plugins/registry.py
+++ b/src/faultray/plugins/registry.py
@@ -8,11 +8,18 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 import importlib.util
 import logging
+import os
 
 if TYPE_CHECKING:
     from faultray.model.graph import InfraGraph
 
 logger = logging.getLogger(__name__)
+
+# Loading a plugin imports and runs its module — arbitrary code execution by
+# design. We refuse to do that for a caller-supplied directory unless the
+# caller explicitly marks it trusted (or the operator opts in via env), so a
+# stray/hostile *.py in a pointed-at directory cannot silently run.
+_PLUGIN_EXEC_ENV = "FAULTRAY_ALLOW_PLUGIN_EXEC"
 
 
 class ScenarioPlugin(Protocol):
@@ -82,10 +89,29 @@ class PluginRegistry:
         cls._discovery_plugins.append(plugin)
 
     @classmethod
-    def load_plugins_from_dir(cls, plugin_dir: Path):
-        """Load all .py files from a directory as plugins."""
+    def load_plugins_from_dir(cls, plugin_dir: Path, trusted: bool = False):
+        """Load all .py files from a directory as plugins.
+
+        Loading executes each module, so this is gated behind an explicit trust
+        decision. Pass ``trusted=True`` (the CLI does this only when the user
+        names a ``--plugins-dir`` and confirms) or set ``FAULTRAY_ALLOW_PLUGIN_EXEC=1``.
+        Without that, the directory is skipped with a warning rather than
+        executing arbitrary code.
+        """
         if not plugin_dir.exists():
             return
+        if not (trusted or os.environ.get(_PLUGIN_EXEC_ENV) == "1"):
+            logger.warning(
+                "Refusing to load plugins from %s: loading runs arbitrary code. "
+                "Pass trusted=True or set %s=1 to opt in.",
+                plugin_dir,
+                _PLUGIN_EXEC_ENV,
+            )
+            return
+        logger.warning(
+            "Executing plugin modules from %s — only do this for directories you trust.",
+            plugin_dir,
+        )
         for py_file in sorted(plugin_dir.glob("*.py")):
             if py_file.name.startswith("_"):
                 continue

--- a/tests/test_admin_auth.py
+++ b/tests/test_admin_auth.py
@@ -303,3 +303,45 @@ class TestSlackSignature:
         finally:
             os.environ.pop("FAULTRAY_ALLOW_UNSIGNED_SLACK", None)
             os.environ.pop("FAULTRAY_ENV", None)
+
+
+# ---------------------------------------------------------------------------
+# First-admin bootstrap gate (#140)
+# ---------------------------------------------------------------------------
+
+async def _delete_all_users() -> None:
+    from sqlalchemy import delete
+
+    sf = get_session_factory()
+    async with sf() as session:
+        await session.execute(delete(UserRow))
+        await session.commit()
+
+
+class TestSetupTokenGate:
+    """When FAULTRAY_SETUP_TOKEN is set, first-admin creation requires it."""
+
+    def test_setup_rejected_without_token(self, anon_client, monkeypatch):
+        monkeypatch.setenv("FAULTRAY_SETUP_TOKEN", "s3cret-bootstrap")
+        _run_async(_delete_all_users())
+        resp = anon_client.post(
+            "/setup", data={"name": "Admin", "email": "a@b.com"}
+        )
+        assert resp.status_code == 403
+
+    def test_setup_accepts_matching_token(self, anon_client, monkeypatch):
+        monkeypatch.setenv("FAULTRAY_SETUP_TOKEN", "s3cret-bootstrap")
+        _run_async(_delete_all_users())
+        resp = anon_client.post(
+            "/setup",
+            data={"name": "Admin", "email": "a@b.com", "setup_token": "s3cret-bootstrap"},
+        )
+        assert resp.status_code == 200
+
+    def test_setup_open_when_token_unset(self, anon_client, monkeypatch):
+        monkeypatch.delenv("FAULTRAY_SETUP_TOKEN", raising=False)
+        _run_async(_delete_all_users())
+        resp = anon_client.post(
+            "/setup", data={"name": "Admin", "email": "a@b.com"}
+        )
+        assert resp.status_code == 200

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -460,14 +460,15 @@ class TestSimulationRunWithDB:
         # Just ensure it doesn't raise
         reset_engine()
 
-    def test_simulation_run_get_saves_to_db(self, demo_db_client):
-        """Cover line 419: run_id is set in response when DB works."""
+    def test_simulation_run_get_does_not_persist(self, demo_db_client):
+        """The public /simulation/run GET must NOT write a run row (#141):
+        anonymous demo traffic should not create unbounded shared state."""
         resp = demo_db_client.get("/simulation/run")
         assert resp.status_code == 200
         data = resp.json()
         assert "resilience_score" in data
-        # run_id should be present when DB is working
-        assert "run_id" in data
+        # Public endpoint no longer persists, so no run_id is returned.
+        assert "run_id" not in data
 
     def test_api_simulate_post_saves_to_db(self, demo_db_client):
         """Cover line 439: run_id is set in post response, plus audit log (line 456)."""

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -137,3 +137,52 @@ class TestGenerateOAuthUrl:
         )
         url = generate_oauth_url(config)
         assert url == ""
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed behaviour when python-jose is unavailable (#137)
+# ---------------------------------------------------------------------------
+
+def test_decode_jwt_rejects_when_jose_missing(monkeypatch):
+    """Without python-jose, decode_jwt must reject every token rather than
+    trust an unsigned, forgeable payload (auth bypass guard)."""
+    import builtins
+    import base64
+    import json as _json
+
+    from faultray.api import oauth
+
+    real_import = builtins.__import__
+
+    def _no_jose(name, *args, **kwargs):
+        if name == "jose" or name.startswith("jose."):
+            raise ImportError("python-jose not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_jose)
+
+    # A hand-forged "token" that the old base64 fallback would have accepted.
+    forged = base64.urlsafe_b64encode(
+        _json.dumps({"sub": "1", "exp": 99999999999}).encode()
+    ).decode()
+    assert oauth.decode_jwt(forged) is None
+
+
+def test_create_jwt_refuses_unsigned_fallback(monkeypatch):
+    """create_jwt must raise (not emit an unsigned token) when jose is absent."""
+    import builtins
+
+    from faultray.api import oauth
+
+    real_import = builtins.__import__
+
+    def _no_jose(name, *args, **kwargs):
+        if name == "jose" or name.startswith("jose."):
+            raise ImportError("python-jose not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_jose)
+
+    import pytest as _pytest
+    with _pytest.raises(RuntimeError):
+        oauth.create_jwt({"sub": "1"})

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -740,3 +740,39 @@ except BaseException:
                 '        g = cls.__dict__["close"].__globals__\n'
                 '        break'
             )
+
+
+# ---------------------------------------------------------------------------
+# Discovery must not execute plugin code (#149)
+# ---------------------------------------------------------------------------
+
+class TestMetadataReadIsStatic:
+    def test_metadata_read_without_executing_module(self, tmp_path: Path):
+        """_read_metadata_from_file extracts PLUGIN_METADATA via AST and must
+        never import the module — a side effect at import time proves a
+        regression to exec-based discovery."""
+        marker = tmp_path / "executed.marker"
+        plugin = tmp_path / "sneaky.py"
+        plugin.write_text(
+            textwrap.dedent(f"""\
+                from pathlib import Path
+                Path({str(marker)!r}).write_text("ran")  # would run if imported
+
+                PLUGIN_METADATA = {{
+                    "name": "sneaky",
+                    "version": "1.0.0",
+                    "type": "scenario_generator",
+                }}
+            """)
+        )
+        meta = PluginManager._read_metadata_from_file(plugin)
+        assert meta is not None
+        assert meta.name == "sneaky"
+        assert not marker.exists(), "module was executed during metadata read"
+
+    def test_non_literal_metadata_is_ignored(self, tmp_path: Path):
+        """A computed (non-literal) PLUGIN_METADATA can't be statically read and
+        must yield None rather than falling back to execution."""
+        plugin = tmp_path / "dynamic.py"
+        plugin.write_text("PLUGIN_METADATA = dict(name='x', version='1.0.0')\n")
+        assert PluginManager._read_metadata_from_file(plugin) is None

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -100,20 +100,48 @@ class TestPluginRegistry:
             """)
         )
 
-        PluginRegistry.load_plugins_from_dir(tmp_path)
+        PluginRegistry.load_plugins_from_dir(tmp_path, trusted=True)
         assert len(PluginRegistry.get_scenario_plugins()) == 1
         assert PluginRegistry.get_scenario_plugins()[0].name == "my-plugin"
 
     def test_load_plugins_skips_underscore_files(self, tmp_path: Path):
         """Files starting with _ should be skipped."""
         (tmp_path / "_internal.py").write_text("raise RuntimeError('should not load')")
-        PluginRegistry.load_plugins_from_dir(tmp_path)
+        PluginRegistry.load_plugins_from_dir(tmp_path, trusted=True)
         assert PluginRegistry.get_scenario_plugins() == []
 
     def test_load_plugins_nonexistent_dir(self, tmp_path: Path):
         """Loading from a non-existent directory should be a no-op."""
         PluginRegistry.load_plugins_from_dir(tmp_path / "nonexistent")
         assert PluginRegistry.get_scenario_plugins() == []
+
+    def test_untrusted_dir_does_not_execute_code(self, tmp_path: Path):
+        """Without trusted=True / the opt-in env, a plugin dir must NOT be
+        executed (security: #150). A module that would crash on import proves
+        it was never run."""
+        (tmp_path / "evil.py").write_text("raise RuntimeError('executed!')")
+        # No exception, no registration — the directory is skipped entirely.
+        PluginRegistry.load_plugins_from_dir(tmp_path)
+        assert PluginRegistry.get_scenario_plugins() == []
+
+    def test_env_opt_in_allows_loading(self, tmp_path: Path, monkeypatch):
+        """FAULTRAY_ALLOW_PLUGIN_EXEC=1 is an accepted opt-in for loading."""
+        plugin_file = tmp_path / "envplugin.py"
+        plugin_file.write_text(
+            textwrap.dedent("""\
+                class EnvPlugin:
+                    name = "env-plugin"
+                    description = "x"
+                    def generate_scenarios(self, graph, component_ids, components):
+                        return []
+
+                def register(registry):
+                    registry.register_scenario(EnvPlugin())
+            """)
+        )
+        monkeypatch.setenv("FAULTRAY_ALLOW_PLUGIN_EXEC", "1")
+        PluginRegistry.load_plugins_from_dir(tmp_path)
+        assert any(p.name == "env-plugin" for p in PluginRegistry.get_scenario_plugins())
 
 
 # ---------------------------------------------------------------------------
@@ -296,7 +324,7 @@ class TestLoadPluginsFromDirExtended:
         """Plugin files with syntax errors should be skipped gracefully."""
         bad_file = tmp_path / "bad_plugin.py"
         bad_file.write_text("def register(registry):\n    raise RuntimeError('boom')\n")
-        PluginRegistry.load_plugins_from_dir(tmp_path)
+        PluginRegistry.load_plugins_from_dir(tmp_path, trusted=True)
         # Should not crash, and no plugins should be registered
         assert len(PluginRegistry.get_scenario_plugins()) == 0
 
@@ -304,7 +332,7 @@ class TestLoadPluginsFromDirExtended:
         """Plugin files without register() should be loaded but not register anything."""
         plugin_file = tmp_path / "no_register.py"
         plugin_file.write_text("x = 42\n")
-        PluginRegistry.load_plugins_from_dir(tmp_path)
+        PluginRegistry.load_plugins_from_dir(tmp_path, trusted=True)
         assert len(PluginRegistry.get_scenario_plugins()) == 0
 
     def test_load_multiple_plugins(self, tmp_path: Path):
@@ -321,5 +349,5 @@ class TestLoadPluginsFromDirExtended:
                 def register(registry):
                     registry.register_scenario(Plugin{i}())
             """))
-        PluginRegistry.load_plugins_from_dir(tmp_path)
+        PluginRegistry.load_plugins_from_dir(tmp_path, trusted=True)
         assert len(PluginRegistry.get_scenario_plugins()) == 3

--- a/tests/test_saas.py
+++ b/tests/test_saas.py
@@ -345,3 +345,24 @@ class TestAuthIntegration:
 
         assert _is_public("/api/v1/billing/checkout") is False
         assert _is_public("/api/v1/billing/portal") is False
+
+
+class TestProtectedSaaSEndpointsRejectUnauthenticated:
+    """Regression guard (#143): every tier-gated v1 SaaS endpoint must reject
+    callers with no credentials. These would have caught the placeholder auth
+    dependency that previously let anonymous requests through.
+    """
+
+    def test_billing_checkout_requires_auth(self, unauth_client):
+        resp = unauth_client.post(
+            "/api/v1/billing/checkout", json={"tier": "pro", "team_id": "t1"}
+        )
+        assert resp.status_code in (401, 403), resp.text
+
+    def test_billing_portal_requires_auth(self, unauth_client):
+        resp = unauth_client.get("/api/v1/billing/portal?team_id=t1")
+        assert resp.status_code in (401, 403), resp.text
+
+    def test_compliance_report_requires_auth(self, unauth_client):
+        resp = unauth_client.get("/api/v1/compliance/report")
+        assert resp.status_code in (401, 403), resp.text


### PR DESCRIPTION
Triaged all 19 open issues against the current code and fixed the ones that are real and code-addressable. Verified: full suite **33,673 passed / 0 failed**, plus 360 targeted tests on the touched modules; ruff clean.

## Fixed in this PR
- **#137** oauth — fail closed when `python-jose` is absent: refuse to issue/accept unsigned base64 "JWTs" that anyone could forge (auth bypass). Production secret guard already in place.
- **#139** `routes/_shared._require_permission` — deny (HTTP 500) on unexpected auth-layer errors instead of returning `None` (fail-open bypass).
- **#140** `/setup` — optional `FAULTRAY_SETUP_TOKEN` gate closes the first-admin race-to-takeover on fresh public instances; default first-run UX unchanged.
- **#141** public `/simulation/run` no longer persists run rows — anonymous demo traffic can't write unbounded shared state.
- **#143** added unauthenticated 401/403 tests for the v1 SaaS billing/compliance endpoints.
- **#144** `faultray-pr-check.yml` installs the checked-out code (`pip install -e .`).
- **#145** `scripts/release.sh` derives the version from `pyproject.toml` + guard.
- **#149** plugin discovery reads `PLUGIN_METADATA` via AST — never imports the module (no code execution when listing plugins).
- **#150** `registry.load_plugins_from_dir` gates execution behind `trusted=True` / `FAULTRAY_ALLOW_PLUGIN_EXEC`; the CLI opts in only when the user names `--plugins-dir`, with a security notice.
- **#151** insurance endpoint returns a generic error; details logged server-side only.
- **#152** `cla.yml` pins the contributor-assistant action to a commit SHA and scopes the comment trigger to PR comments.

## Secret-reintroduction hardening (#136 / #147 / #148)
The flagged files aren't in the repo (`.env`, `marketing/publish-devto.sh`, `docs/patent/` are untracked / absent) and `.env` is already gitignored + dockerignored with a gitleaks CI workflow. Added a **gitleaks pre-commit hook** and `.gitignore` rules for `.env*`, `docs/patent/`, `marketing/publish-*.sh`. **Rotating the actual tokens remains the owner's action** — I can't do that from here.

## Verified already-fixed (closed separately)
#138, #142, #146 were resolved by earlier PRs #168/#169.

## Not code-fixable here
#128 targets `faultray-landing` (separate repo); #129 is a strategy/audit-trail tracker about a past merged PR.

https://claude.ai/code/session_01Fpe2z3KCqdYVPVo574N3Pu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fpe2z3KCqdYVPVo574N3Pu)_